### PR TITLE
Tracking lesson progress

### DIFF
--- a/app/models/course_lesson_progress.rb
+++ b/app/models/course_lesson_progress.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CourseLessonProgress < ApplicationRecord
+  belongs_to :course_lesson
+  belongs_to :early_career_teacher_profile
+
+  validates :course_lesson_id, uniqueness: { scope: :early_career_teacher_profile_id }
+  validates :progress, inclusion: { in: %w[not_started complete] }
+end

--- a/app/models/course_lesson_progress.rb
+++ b/app/models/course_lesson_progress.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class CourseLessonProgress < ApplicationRecord
+  enum progress: { not_started: "not_started", complete: "complete" }
+
   belongs_to :course_lesson
   belongs_to :early_career_teacher_profile
 
   validates :course_lesson_id, uniqueness: { scope: :early_career_teacher_profile_id }
-  validates :progress, inclusion: { in: %w[not_started complete] }
 end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -4,4 +4,7 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :user
   belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true
+
+  has_many :course_lesson_progresses
+  has_many :course_lessons, through: :course_lesson_progresses
 end

--- a/db/migrate/20210209172653_create_course_lesson_progresses.rb
+++ b/db/migrate/20210209172653_create_course_lesson_progresses.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCourseLessonProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :course_lesson_progresses, id: :uuid do |t|
+      t.string :progress, default: "not_started"
+      t.references :early_career_teacher_profile, null: false, foreign_key: true, index: { name: :idx_course_lesson_progresses_on_ect_profile_id }
+      t.references :course_lesson, null: false, foreign_key: true, index: { name: :idx_course_lesson_progresses_on_course_lesson_id }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210210120844_add_uniqueness_constraint_to_course_lesson_progresses.rb
+++ b/db/migrate/20210210120844_add_uniqueness_constraint_to_course_lesson_progresses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniquenessConstraintToCourseLessonProgresses < ActiveRecord::Migration[6.1]
+  def change
+    change_table :course_lesson_progresses do |t|
+      t.index %w[course_lesson_id early_career_teacher_profile_id], unique: true, name: "idx_cl_progresses_on_cl_id_and_ect_profile_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_163654) do
+ActiveRecord::Schema.define(version: 2021_02_10_120844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -33,6 +33,17 @@ ActiveRecord::Schema.define(version: 2021_02_09_163654) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "course_lesson_progresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "progress", default: "not_started"
+    t.uuid "early_career_teacher_profile_id", null: false
+    t.uuid "course_lesson_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_lesson_id", "early_career_teacher_profile_id"], name: "idx_cl_progresses_on_cl_id_and_ect_profile_id", unique: true
+    t.index ["course_lesson_id"], name: "idx_course_lesson_progresses_on_course_lesson_id"
+    t.index ["early_career_teacher_profile_id"], name: "idx_course_lesson_progresses_on_ect_profile_id"
   end
 
   create_table "course_lessons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -125,6 +136,8 @@ ActiveRecord::Schema.define(version: 2021_02_09_163654) do
   end
 
   add_foreign_key "admin_profiles", "users"
+  add_foreign_key "course_lesson_progresses", "course_lessons"
+  add_foreign_key "course_lesson_progresses", "early_career_teacher_profiles"
   add_foreign_key "course_lessons", "course_lessons", column: "previous_lesson_id"
   add_foreign_key "course_lessons", "course_modules"
   add_foreign_key "course_modules", "course_modules", column: "previous_module_id"

--- a/spec/factories/course_lesson_progresses.rb
+++ b/spec/factories/course_lesson_progresses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course_lesson_progress do
+    progress { "not_started" }
+    course_lesson
+    early_career_teacher_profile
+  end
+end

--- a/spec/models/course_lesson_progress_spec.rb
+++ b/spec/models/course_lesson_progress_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseLessonProgress, type: :model do
+  it "is created with the default progress value" do
+    course_lesson = CourseLessonProgress.new
+    expect(course_lesson[:progress]).to eql("not_started")
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:course_lesson) }
+    it { is_expected.to belong_to(:early_career_teacher_profile) }
+  end
+
+  describe "validations" do
+    subject { create(:course_lesson_progress) }
+    it { is_expected.to validate_uniqueness_of(:course_lesson_id).scoped_to(:early_career_teacher_profile_id).case_insensitive }
+  end
+
+  describe "early_career_teacher_profile" do
+    context "when early career teachers have records of course lesson progresses" do
+      let(:teacher) { create(:early_career_teacher_profile) }
+      let(:lesson_one) { create(:course_lesson) }
+      let(:lesson_two) { create(:course_lesson) }
+      let!(:lesson_one_progress) { create(:course_lesson_progress, early_career_teacher_profile: teacher, course_lesson: lesson_one) }
+
+      it "matches a created course lesson progress to a teachers course lesson progresses" do
+        expect(teacher.course_lesson_progresses[0]).to eq(lesson_one_progress)
+      end
+
+      it "adds a second lesson record to a teachers progresses" do
+        create(:course_lesson_progress, early_career_teacher_profile: teacher, course_lesson: lesson_two)
+        expect(teacher.course_lesson_progresses.count).to eql(2)
+      end
+
+      it "updates a single lesson record" do
+        lesson_one_progress.update!(progress: "complete")
+        completed_lesson = teacher.course_lesson_progresses.find_by(course_lesson_id: lesson_one)
+        expect(completed_lesson[:progress]).to eql("complete")
+      end
+
+      it "can not assign an invalid status to a course lesson progress" do
+        lesson_one_progress.progress = "part way through"
+        expect(lesson_one_progress).not_to be_valid
+      end
+
+      it "does not allow the same lesson record progress to be added twice" do
+        lesson_one_progress_duplicate = CourseLessonProgress.new(
+          early_career_teacher_profile: teacher,
+          course_lesson: lesson_one,
+        )
+        expect(lesson_one_progress_duplicate).not_to be_valid
+      end
+
+      it "creates a second course lesson progress record" do
+        create(:course_lesson_progress, early_career_teacher_profile: teacher, course_lesson: lesson_two)
+        expect(teacher.course_lesson_progresses.count).to eql(2)
+      end
+    end
+  end
+end

--- a/spec/models/course_lesson_progress_spec.rb
+++ b/spec/models/course_lesson_progress_spec.rb
@@ -52,11 +52,6 @@ RSpec.describe CourseLessonProgress, type: :model do
         )
         expect(lesson_one_progress_duplicate).not_to be_valid
       end
-
-      it "creates a second course lesson progress record" do
-        create(:course_lesson_progress, early_career_teacher_profile: teacher, course_lesson: lesson_two)
-        expect(teacher.course_lesson_progresses.count).to eql(2)
-      end
     end
   end
 end

--- a/spec/models/course_lesson_progress_spec.rb
+++ b/spec/models/course_lesson_progress_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe CourseLessonProgress, type: :model do
       end
 
       it "can not assign an invalid status to a course lesson progress" do
-        lesson_one_progress.progress = "part way through"
-        expect(lesson_one_progress).not_to be_valid
+        expect { lesson_one_progress.progress = "part_way_through" }.to raise_error ArgumentError
       end
 
       it "does not allow the same lesson record progress to be added twice" do

--- a/spec/models/early_career_teacher_profile.rb
+++ b/spec/models/early_career_teacher_profile.rb
@@ -7,5 +7,7 @@ RSpec.describe EarlyCareerTeacherProfile, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:core_induction_programme).optional }
     it { is_expected.to belong_to(:cohort).optional }
+    it { is_expected.to have_many(:course_lesson_progresses) }
+    it { is_expected.to have_many(:course_lessons).through(:course_lesson_progresses) }
   end
 end


### PR DESCRIPTION
### Context
Teachers need to be able to track their progress for individual lessons, to be able to do this we need to link up early career teachers and course lessons. 

### Changes proposed in this pull request
- Adding migrations that create CourseLessonProgress table and add a uniqueness constraint so as not to generate duplicate records of a teachers progress against the same lesson.
- Updated Schema
- Adding model tests for CourseLessonProgresses, along with a Factory
- Additional association tests for EarlyCareerTeacherProfile model

### Guidance to review
I've only included two course lesson progress states for the minute. These are likely to be added too later on. 

### Testing
As mentioned above. 