### PR TITLE
Add breadcrumbs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+# Find an object to check against
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
+    # If we have a commit, use it
     against=HEAD
 else
-    # Initial commit: diff against an empty tree object
-    against=6aef4de
+    # If we don't, diff against empty object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
 # Redirect output to stderr.

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -3,6 +3,7 @@
 class CoreInductionProgramme::LessonsController < ApplicationController
   include Pundit
   include GovspeakHelper
+  include CipBreadcrumbHelper
 
   after_action :verify_authorized, except: :show
   before_action :authenticate_user!, except: :show

--- a/app/controllers/core_induction_programme/modules_controller.rb
+++ b/app/controllers/core_induction_programme/modules_controller.rb
@@ -3,6 +3,7 @@
 class CoreInductionProgramme::ModulesController < ApplicationController
   include Pundit
   include GovspeakHelper
+  include CipBreadcrumbHelper
 
   after_action :verify_authorized, except: :show
   before_action :authenticate_user!, except: :show

--- a/app/controllers/core_induction_programme/years_controller.rb
+++ b/app/controllers/core_induction_programme/years_controller.rb
@@ -3,6 +3,7 @@
 class CoreInductionProgramme::YearsController < ApplicationController
   include Pundit
   include GovspeakHelper
+  include CipBreadcrumbHelper
 
   after_action :verify_authorized, except: :show
   before_action :authenticate_user!, except: :show

--- a/app/helpers/cip_breadcrumb_helper.rb
+++ b/app/helpers/cip_breadcrumb_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module CipBreadcrumbHelper
+  def course_year_breadcrumbs(user)
+    [home_crumb(user)]
+  end
+
+  def course_module_breadcrumbs(user, course_module)
+    [
+      home_crumb(user),
+      course_module_crumb(course_module),
+    ]
+  end
+
+  def course_lesson_breadcrumbs(user, course_lesson)
+    [
+      home_crumb(user),
+      course_module_crumb(course_lesson.course_module),
+      course_lesson_crumb(course_lesson),
+    ]
+  end
+
+private
+
+  def home_crumb(user)
+    ["Home", user ? dashboard_path : cip_path]
+  end
+
+  def course_module_crumb(course_module)
+    [course_module.course_year.title, cip_year_path(course_module.course_year)]
+  end
+
+  def course_lesson_crumb(course_lesson)
+    [course_lesson.course_module.title, cip_year_module_path(course_lesson.course_module.course_year, course_lesson.course_module)]
+  end
+end

--- a/app/views/core_induction_programme/lessons/edit.html.erb
+++ b/app/views/core_induction_programme/lessons/edit.html.erb
@@ -1,3 +1,7 @@
+<%= govuk_breadcrumbs breadcrumbs: [
+  ["Home", @current_user ? dashboard_path : cip_path],
+  [@course_lesson.course_module.course_year.title, cip_year_path(@course_lesson.course_module.course_year)],
+  [@course_lesson.course_module.title, cip_year_module_path(@course_lesson.course_module.course_year, @course_lesson.course_module)]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/lessons/edit.html.erb
+++ b/app/views/core_induction_programme/lessons/edit.html.erb
@@ -1,7 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [
-  ["Home", @current_user ? dashboard_path : cip_path],
-  [@course_lesson.course_module.course_year.title, cip_year_path(@course_lesson.course_module.course_year)],
-  [@course_lesson.course_module.title, cip_year_module_path(@course_lesson.course_module.course_year, @course_lesson.course_module)]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,7 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [
-  ["Home", @current_user ? dashboard_path : cip_path],
-  [@course_lesson.course_module.course_year.title, cip_year_path(@course_lesson.course_module.course_year)],
-  [@course_lesson.course_module.title, cip_year_module_path(@course_lesson.course_module.course_year, @course_lesson.course_module)]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if policy(@course_lesson).edit? %>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,3 +1,7 @@
+<%= govuk_breadcrumbs breadcrumbs: [
+  ["Home", @current_user ? dashboard_path : cip_path],
+  [@course_lesson.course_module.course_year.title, cip_year_path(@course_lesson.course_module.course_year)],
+  [@course_lesson.course_module.title, cip_year_module_path(@course_lesson.course_module.course_year, @course_lesson.course_module)]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if policy(@course_lesson).edit? %>

--- a/app/views/core_induction_programme/modules/edit.html.erb
+++ b/app/views/core_induction_programme/modules/edit.html.erb
@@ -1,6 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [
-  ["Home", @current_user ? dashboard_path : cip_path],
-  [@course_module.course_year.title, cip_year_path(@course_module.course_year)]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_module_breadcrumbs(@current_user, @course_module) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/modules/edit.html.erb
+++ b/app/views/core_induction_programme/modules/edit.html.erb
@@ -1,3 +1,6 @@
+<%= govuk_breadcrumbs breadcrumbs: [
+  ["Home", @current_user ? dashboard_path : cip_path],
+  [@course_module.course_year.title, cip_year_path(@course_module.course_year)]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,3 +1,6 @@
+<%= govuk_breadcrumbs breadcrumbs: [
+  ["Home", @current_user ? dashboard_path : cip_path],
+  [@course_module.course_year.title, cip_year_path(@course_module.course_year)]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if policy(@course_module).edit? %>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,6 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [
-  ["Home", @current_user ? dashboard_path : cip_path],
-  [@course_module.course_year.title, cip_year_path(@course_module.course_year)]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_module_breadcrumbs(@current_user, @course_module) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if policy(@course_module).edit? %>

--- a/app/views/core_induction_programme/years/edit.html.erb
+++ b/app/views/core_induction_programme/years/edit.html.erb
@@ -1,3 +1,4 @@
+<%= govuk_breadcrumbs breadcrumbs: [["Home", @current_user ? dashboard_path : cip_path]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/years/edit.html.erb
+++ b/app/views/core_induction_programme/years/edit.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [["Home", @current_user ? dashboard_path : cip_path]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: [["Home", @current_user ? dashboard_path : cip_path]] %>
+<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if policy(@course_year).edit? %>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,3 +1,4 @@
+<%= govuk_breadcrumbs breadcrumbs: [["Home", @current_user ? dashboard_path : cip_path]] %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if policy(@course_year).edit? %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -4,9 +4,20 @@
     <p class="govuk-body"> You are logged in</p>
 
     <% if @current_user.early_career_teacher? %>
-      <h2 class="govuk-heading-l">Your Core Induction Programme</h2>
       <% if @current_user.course_years.each do |course_year| %>
-        <p><%= govuk_link_to course_year.title, cip_year_url(course_year) %></p>
+        <h2 class="govuk-heading-l"><%= course_year.title %></h2>
+
+        <% if course_year.course_modules.each do |course_module| %>
+          <li class="app-task-list__item">
+            <span>
+              <%= govuk_link_to course_module.title, cip_year_module_path(course_module.course_year, course_module) %>
+            </span>
+            <strong class="govuk-tag app-task-list__tag">complete</strong>
+          </li>
+        <% end.empty? %>
+          <p>No course modules were found!</p>
+        <% end %>
+
       <% end.empty? %>
         <p>You have not been enrolled in Core Induction Programme yet!</p>
       <% end %>


### PR DESCRIPTION
### Context
I want CIP navigation to be easier

### Changes proposed in this pull request
Add breadcrumbs using govuk-components to our cip pages. 'home' should go to dashboard when user is logged in, and to cip page otherwise.

Add list of modules to ect dashboard.

### Guidance to review
Commit by commit, maybe check out the review app. `early-career-teacher@example.com` should log you in to the dashboard. 

### Testing
We will probably need to add some cypress tests for it later. 