### PR TITLE
Add mentor profile

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,7 +4,7 @@ class Users::SessionsController < Devise::SessionsController
   class EmailNotFoundError < StandardError; end
   class LoginIncompleteError < StandardError; end
 
-  TEST_USERS = %w[admin@example.com early-career-teacher@example.com].freeze
+  TEST_USERS = %w[admin@example.com early-career-teacher@example.com mentor@example.com].freeze
 
   before_action :mock_login, only: :create, if: -> { Rails.env.development? || Rails.env.deployed_development? }
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -5,7 +5,6 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true
   belongs_to :mentor_profile, optional: true
-
   has_one  :mentor, through: :mentor_profile, source: :user
 
   has_many :course_lesson_progresses

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -4,6 +4,9 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :user
   belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true
+  belongs_to :mentor_profile, optional: true
+
+  has_one  :mentor, through: :mentor_profile, source: :user
 
   has_many :course_lesson_progresses
   has_many :course_lessons, through: :course_lesson_progresses

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MentorProfile < ApplicationRecord
+  belongs_to :user
+  has_many :early_career_teacher_profiles
+  has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,9 @@ class User < ApplicationRecord
   has_one :admin_profile
 
   has_one :early_career_teacher_profile
+
+  has_one :mentor_profile
+
   has_one :core_induction_programme, through: :early_career_teacher_profile
   has_many :course_years, through: :core_induction_programme
 
@@ -24,5 +27,9 @@ class User < ApplicationRecord
 
   def early_career_teacher?
     early_career_teacher_profile.present?
+  end
+
+  def mentor?
+    mentor_profile.present?
   end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -2,15 +2,23 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">User dashboard</h1>
     <p class="govuk-body"> You are logged in</p>
-
     <% if @current_user.early_career_teacher? %>
       <h2 class="govuk-heading-l">Your Core Induction Programme</h2>
-      <% if @current_user.course_years.each do |course_year| %>
+      <% @current_user.course_years.each do |course_year| %>
         <p><%= govuk_link_to course_year.title, cip_year_url(course_year) %></p>
-      <% end.empty? %>
+      <% end %>
+      <% if @current_user.course_years.empty? %>
         <p>You have not been enrolled in Core Induction Programme yet!</p>
       <% end %>
     <% end %>
-
+    <%if @current_user.mentor? %>
+      <h2 class="govuk-heading-l">Your list of mentees</h2>
+      <% @current_user.mentor_profile.early_career_teachers.each do |early_career_teacher| %>
+        <p><%= early_career_teacher.full_name %></p>
+      <% end %>
+      <% if @current_user.mentor_profile.early_career_teachers.empty? %>
+        <p>You have no mentees</p>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/db/migrate/20210215114306_create_mentor_profiles.rb
+++ b/db/migrate/20210215114306_create_mentor_profiles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateMentorProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :mentor_profiles do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210215121631_add_mentor_profile_to_early_career_teacher_profile.rb
+++ b/db/migrate/20210215121631_add_mentor_profile_to_early_career_teacher_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMentorProfileToEarlyCareerTeacherProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :early_career_teacher_profiles, :mentor_profile, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_10_120844) do
+ActiveRecord::Schema.define(version: 2021_02_15_121631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,8 +103,10 @@ ActiveRecord::Schema.define(version: 2021_02_10_120844) do
     t.uuid "cohort_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "mentor_profile_id"
     t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
+    t.index ["mentor_profile_id"], name: "index_early_career_teacher_profiles_on_mentor_profile_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
   end
 
@@ -113,6 +115,13 @@ ActiveRecord::Schema.define(version: 2021_02_10_120844) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_induction_coordinator_profiles_on_user_id"
+  end
+
+  create_table "mentor_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_mentor_profiles_on_user_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -145,6 +154,8 @@ ActiveRecord::Schema.define(version: 2021_02_10_120844) do
   add_foreign_key "course_years", "core_induction_programmes"
   add_foreign_key "early_career_teacher_profiles", "cohorts"
   add_foreign_key "early_career_teacher_profiles", "core_induction_programmes"
+  add_foreign_key "early_career_teacher_profiles", "mentor_profiles"
   add_foreign_key "early_career_teacher_profiles", "users"
   add_foreign_key "induction_coordinator_profiles", "users"
+  add_foreign_key "mentor_profiles", "users"
 end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -22,11 +22,19 @@ if Rails.env.development? || Rails.env.deployed_development?
     InductionCoordinatorProfile.create!(user: user)
   end
 
+  if MentorProfile.none?
+    user = User.find_or_create_by!(email: "mentor@example.com") do |u|
+      u.full_name = "Mentor User"
+      u.confirmed_at = Time.zone.now.utc
+    end
+    MentorProfile.create!(user: user)
+  end
+
   if EarlyCareerTeacherProfile.none?
     user = User.find_or_create_by!(email: "early-career-teacher@example.com") do |u|
       u.full_name = "ECT User"
       u.confirmed_at = Time.zone.now.utc
     end
-    EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first)
+    EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first, mentor: MentorProfile.first)
   end
 end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -35,6 +35,6 @@ if Rails.env.development? || Rails.env.deployed_development?
       u.full_name = "ECT User"
       u.confirmed_at = Time.zone.now.utc
     end
-    EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first, mentor: MentorProfile.first)
+    EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first, mentor_profile: MentorProfile.first)
   end
 end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :mentor_profile do
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :early_career_teacher do
       early_career_teacher_profile
     end
+
+    trait :mentor do
+      mentor_profile
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,19 +9,19 @@ FactoryBot.define do
     login_token_valid_until { 1.hour.from_now }
 
     trait :admin do
-      admin_profile
+      admin_profile { build(:admin_profile) }
     end
 
     trait :induction_coordinator do
-      induction_coordinator_profile
+      induction_coordinator_profile { build(:induction_coordinator_profile) }
     end
 
     trait :early_career_teacher do
-      early_career_teacher_profile
+      early_career_teacher_profile { build(:early_career_teacher_profile) }
     end
 
     trait :mentor do
-      mentor_profile
+      mentor_profile { build(:mentor_profile) }
     end
   end
 end

--- a/spec/models/early_career_teacher_profile.rb
+++ b/spec/models/early_career_teacher_profile.rb
@@ -7,6 +7,8 @@ RSpec.describe EarlyCareerTeacherProfile, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:core_induction_programme).optional }
     it { is_expected.to belong_to(:cohort).optional }
+    it { is_expected.to belong_to(:mentor_profile).optional }
+    it { is_expected.to have_one(:mentor).through(:mentor_profile) }
     it { is_expected.to have_many(:course_lesson_progresses) }
     it { is_expected.to have_many(:course_lessons).through(:course_lesson_progresses) }
   end

--- a/spec/models/mentor_profile_spec.rb
+++ b/spec/models/mentor_profile_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MentorProfile, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:early_career_teacher_profiles) }
+    it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
+  end
+end


### PR DESCRIPTION
### Context 
There will be mentors for ECF that will need to access the service. This adds the initial creation of these users.

### Changes proposed in this pull request
- Migrations to add MentorProfile and linking ECTProfiles to a mentor
- Updated Schema
- MentorProfile model tests
- Updated ECTProfile model tests
- Creating a Mentor in dummy seed data, with a ECT being assigned a Mentor
- Mentor email added to test users to log in automatically.

### Guidance to review


### Testing
As above
