### PR TITLE
Split lesson parts

### DIFF
--- a/app/controllers/core_induction_programme/lesson_parts_controller.rb
+++ b/app/controllers/core_induction_programme/lesson_parts_controller.rb
@@ -29,7 +29,7 @@ class CoreInductionProgramme::LessonPartsController < ApplicationController
 
   def split
     @split_lesson_part_form = SplitLessonPartForm.new(lesson_split_params)
-    if @split_lesson_part_form.valid?
+    if @split_lesson_part_form.valid? && params[:commit] == "Save changes"
       ActiveRecord::Base.transaction do
         @new_course_lesson_part = CourseLessonPart.create!(
           title: @split_lesson_part_form.new_title,

--- a/app/controllers/core_induction_programme/lesson_parts_controller.rb
+++ b/app/controllers/core_induction_programme/lesson_parts_controller.rb
@@ -23,15 +23,44 @@ class CoreInductionProgramme::LessonPartsController < ApplicationController
     end
   end
 
+  def show_split
+    @split_lesson_part_form = SplitLessonPartForm.new(title: @course_lesson_part.title, content: @course_lesson_part.content)
+  end
+
+  def split
+    @split_lesson_part_form = SplitLessonPartForm.new(lesson_split_params)
+    if @split_lesson_part_form.valid?
+      ActiveRecord::Base.transaction do
+        @new_course_lesson_part = CourseLessonPart.create!(
+          title: @split_lesson_part_form.new_title,
+          content: @split_lesson_part_form.new_content,
+          course_lesson: @course_lesson_part.course_lesson,
+          next_lesson_part: @course_lesson_part.next_lesson_part,
+          previous_lesson_part: @course_lesson_part,
+        )
+        @course_lesson_part.update!(title: @split_lesson_part_form.title, content: @split_lesson_part_form.content)
+      end
+      redirect_to cip_year_module_lesson_part_url(id: params[:part_id])
+    else
+      render action: "show_split"
+    end
+  rescue ActiveRecord::RecordInvalid
+    render action: "show_split"
+  end
+
 private
 
   def load_course_lesson_part
-    @course_lesson_part = CourseLessonPart.find(params[:id])
+    @course_lesson_part = CourseLessonPart.find(params[:id] || params[:part_id])
     authorize @course_lesson_part
     @course_lesson_part.assign_attributes(course_lesson_part_params)
   end
 
   def course_lesson_part_params
     params.permit(:content, :title)
+  end
+
+  def lesson_split_params
+    params.require(:split_lesson_part_form).permit(:title, :content, :new_title, :new_content)
   end
 end

--- a/app/forms/split_lesson_part_form.rb
+++ b/app/forms/split_lesson_part_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SplitLessonPartForm
+  include ActiveModel::Model
+
+  attr_accessor :title, :content, :new_title, :new_content
+
+  validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
+  validates :content, presence: { message: "Enter content" }, length: { maximum: 100_000 }
+  validates :new_title, presence: { message: "Enter a title" }, length: { maximum: 255 }
+  validates :new_content, presence: { message: "Enter content" }, length: { maximum: 100_000 }
+end

--- a/app/policies/course_lesson_part_policy.rb
+++ b/app/policies/course_lesson_part_policy.rb
@@ -17,4 +17,12 @@ class CourseLessonPartPolicy < ApplicationPolicy
   def update?
     admin_only
   end
+
+  def show_split?
+    edit?
+  end
+
+  def split?
+    update?
+  end
 end

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -8,6 +8,9 @@
     <% if policy(@course_lesson_part).edit? %>
       <%= link_to "Edit lesson content", edit_cip_year_module_lesson_part_path(@course_lesson_part), class: "govuk-button" %>
     <% end %>
+    <% if policy(@course_lesson_part).show_split? %>
+      <%= link_to "Split lesson content", cip_year_module_lesson_part_split_path(part_id: @course_lesson_part.id), class: "govuk-button" %>
+    <% end %>
 
     <h1 class="govuk-heading-xl"> <%= @course_lesson_part.course_lesson.title %></h1>
     <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>

--- a/app/views/core_induction_programme/lesson_parts/show_split.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show_split.html.erb
@@ -1,5 +1,19 @@
 <%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
-<h1 class="govuk-heading-l">Content change preview</h1>
+<h1 class="govuk-heading-l">Split lesson part</h1>
+<ul>
+  <li>
+    The part on the left hand side is the one you are splitting (current).
+  </li>
+  <li>
+    The part on the right is the new part.
+  </li>
+  <li>
+    If current part is not last, the new part will be inserted between the current part and the next part.
+  </li>
+  <li>
+    If the current part is last, the new part will become last.
+  </li>
+</ul>
 
 <div style="width: 90vw; margin-left: calc(480px - 45vw)">
   <%= form_with model: @split_lesson_part_form, url: cip_year_module_lesson_part_split_path, method: :post do |f| %>
@@ -7,12 +21,12 @@
 
       <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <%= f.govuk_text_field :title, label: { text: "Part one title" } %>
-        <%= f.govuk_text_area :content, label: { text: "Part one content" }, rows: 10 %>
+        <%= f.govuk_text_field :title, label: { text: "Current part title" } %>
+        <%= f.govuk_text_area :content, label: { text: "Current part content" }, rows: 10 %>
       </div>
       <div class="govuk-grid-column-one-half">
-      <%= f.govuk_text_field :new_title, label: { text: "Part two title" } %>
-        <%= f.govuk_text_area :new_content, label: { text: "Part two content" }, rows: 10 %>
+      <%= f.govuk_text_field :new_title, label: { text: "New part title" } %>
+        <%= f.govuk_text_area :new_content, label: { text: "New part content" }, rows: 10 %>
       </div>
     </div>
     <%= f.govuk_submit "See preview" %>

--- a/app/views/core_induction_programme/lesson_parts/show_split.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show_split.html.erb
@@ -1,34 +1,39 @@
-<%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
-<h1 class="govuk-heading-l">Split lesson part</h1>
-<ul>
-  <li>
-    The part on the left hand side is the one you are splitting (current).
-  </li>
-  <li>
-    The part on the right is the new part.
-  </li>
-  <li>
-    If current part is not last, the new part will be inserted between the current part and the next part.
-  </li>
-  <li>
-    If the current part is last, the new part will become last.
-  </li>
-</ul>
+<% content_for :outside_container do %>
+<div class="govuk-width-container govuk-main-wrapper govuk-body">
+  <%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
+  <h1 class="govuk-heading-l">Split lesson part</h1>
+  <ul>
+    <li>
+      The part on the left hand side is the one you are splitting (current).
+    </li>
+    <li>
+      The part on the right is the new part.
+    </li>
+    <li>
+      If current part is not last, the new part will be inserted between the current part and the next part.
+    </li>
+    <li>
+      If the current part is last, the new part will become last.
+    </li>
+  </ul>
+</div>
 
-<div style="width: 90vw; margin-left: calc(480px - 45vw)">
+<main class="govuk-body outside-content-wrapper" id="main-content" role="main">
   <%= form_with model: @split_lesson_part_form, url: cip_year_module_lesson_part_split_path, method: :post do |f| %>
-      <%= f.govuk_error_summary %>
+    <%= f.govuk_error_summary %>
 
-      <div class="govuk-grid-row">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <%= f.govuk_text_field :title, label: { text: "Current part title" } %>
         <%= f.govuk_text_area :content, label: { text: "Current part content" }, rows: 10 %>
       </div>
+
       <div class="govuk-grid-column-one-half">
       <%= f.govuk_text_field :new_title, label: { text: "New part title" } %>
         <%= f.govuk_text_area :new_content, label: { text: "New part content" }, rows: 10 %>
       </div>
     </div>
+
     <%= f.govuk_submit "See preview" %>
     <%= f.govuk_submit "Save changes" %>
   <% end %>
@@ -40,6 +45,7 @@
         <%= content_to_html(@split_lesson_part_form.content).html_safe %>
       </div>
     </div>
+
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l"><%= @split_lesson_part_form.new_title %></h2>
       <div class="gem-c-govspeak govuk-govspeak ">
@@ -47,4 +53,5 @@
       </div>
     </div>
   </div>
-</div>
+</main>
+<% end %>

--- a/app/views/core_induction_programme/lesson_parts/show_split.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show_split.html.erb
@@ -1,0 +1,36 @@
+<%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
+<h1 class="govuk-heading-l">Content change preview</h1>
+
+<div style="width: 90vw; margin-left: calc(480px - 45vw)">
+  <%= form_with model: @split_lesson_part_form, url: cip_year_module_lesson_part_split_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <%= f.govuk_text_field :title, label: { text: "Part one title" } %>
+        <%= f.govuk_text_area :content, label: { text: "Part one content" }, rows: 10 %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+      <%= f.govuk_text_field :new_title, label: { text: "Part two title" } %>
+        <%= f.govuk_text_area :new_content, label: { text: "Part two content" }, rows: 10 %>
+      </div>
+    </div>
+    <%= f.govuk_submit "See preview" %>
+    <%= f.govuk_submit "Save changes" %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-l"><%= @split_lesson_part_form.title %></h2>
+      <div class="gem-c-govspeak govuk-govspeak ">
+        <%= content_to_html(@split_lesson_part_form.content).html_safe %>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-l"><%= @split_lesson_part_form.new_title %></h2>
+      <div class="gem-c-govspeak govuk-govspeak ">
+        <%= content_to_html(@split_lesson_part_form.new_content).html_safe %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,6 +76,8 @@
       </div>
     </div>
 
+    <%= yield(:outside_container) %>
+
     <div class="govuk-width-container">
       <%= yield(:before_content) %>
 

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -18,3 +18,8 @@ $govuk-image-url-function: frontend-image-url;
 @import "~accessible-autocomplete";
 
 @import "govspeak";
+
+.outside-content-wrapper {
+  width: 90%;
+  margin:auto;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,10 @@ Rails.application.routes.draw do
     resources :years, controller: "core_induction_programme/years", only: %i[show edit update] do
       resources :modules, controller: "core_induction_programme/modules", only: %i[show edit update] do
         resources :lessons, controller: "core_induction_programme/lessons", only: %i[show edit update] do
-          resources :parts, controller: "core_induction_programme/lesson_parts", only: %i[show edit update]
+          resources :parts, controller: "core_induction_programme/lesson_parts", only: %i[show edit update] do
+            get "split", to: "core_induction_programme/lesson_parts#show_split", as: "split"
+            post "split", to: "core_induction_programme/lesson_parts#split"
+          end
           resource :progress, controller: "core_induction_programme/progress", only: %i[update]
         end
       end

--- a/spec/forms/split_lesson_part_form.rb
+++ b/spec/forms/split_lesson_part_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SplitLessonPartForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
+    it { is_expected.to validate_length_of(:title).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
+    it { is_expected.to validate_length_of(:content).is_at_most(100_000) }
+
+    it { is_expected.to validate_presence_of(:new_title).with_message("Enter a title") }
+    it { is_expected.to validate_length_of(:new_title).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:new_content).with_message("Enter content") }
+    it { is_expected.to validate_length_of(:new_content).is_at_most(100_000) }
+  end
+end

--- a/spec/policies/course_lesson_part_policy_spec.rb
+++ b/spec/policies/course_lesson_part_policy_spec.rb
@@ -10,23 +10,31 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     let(:user) { create(:user, :admin) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_action(:show_split) }
+    it { is_expected.to permit_action(:split) }
   end
 
   context "trying to edit as user" do
     let(:user) { create(:user) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:show_split) }
+    it { is_expected.to forbid_action(:split) }
   end
 
   context "trying to edit as ECT" do
     let(:user) { create(:user, :early_career_teacher) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:show_split) }
+    it { is_expected.to forbid_action(:split) }
   end
 
   context "being a visitor" do
     let(:user) { nil }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:show_split) }
+    it { is_expected.to forbid_action(:split) }
   end
 end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
         expect(response.body).to include("New title")
       end
     end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "renders the cip lesson part split page" do
+        get "#{course_lesson_part_url}/split"
+        expect(response).to render_template(:show_split)
+      end
+    end
+
+    describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "splits the lesson part and redirects to show" do
+        post "#{course_lesson_part_url}/split", params: { split_lesson_part_form: {
+          title: "Updated title one",
+          content: "Updated content",
+          new_title: "Title two",
+          new_content: "Content two",
+        } }
+        expect(response).to redirect_to(course_lesson_part_url)
+
+        expect(CourseLessonPart.count).to eq(2)
+        course_lesson_part.reload
+        expect(course_lesson_part.title).to eq "Updated title one"
+        expect(course_lesson_part.content).to eq "Updated content"
+        expect(course_lesson_part.next_lesson_part.title).to eq "Title two"
+        expect(course_lesson_part.next_lesson_part.content).to eq "Content two"
+      end
+    end
   end
 
   describe "when a non-admin user is logged in" do
@@ -70,6 +96,18 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/edit" do
       it "redirects to the sign in page" do
         expect { get "#{course_lesson_part_url}/edit" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "redirects to the sign in page" do
+        expect { get "#{course_lesson_part_url}/split" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "redirects to the sign in page" do
+        expect { post "#{course_lesson_part_url}/split" }.to raise_error Pundit::NotAuthorizedError
       end
     end
   end
@@ -92,6 +130,20 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     describe "PUT /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id" do
       it "redirects to the sign in page" do
         put course_lesson_part_url, params: { commit: "Save changes", content: course_lesson_part.content }
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "redirects to the sign in page" do
+        get "#{course_lesson_part_url}/split"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "redirects to the sign in page" do
+        post "#{course_lesson_part_url}/split"
         expect(response).to redirect_to("/users/sign_in")
       end
     end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -61,13 +61,37 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     end
 
     describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
+      it "renders a preview of changes to lesson part" do
+        post "#{course_lesson_part_url}/split", params: {
+          commit: "See preview",
+          split_lesson_part_form: {
+            title: "Updated title one",
+            content: "Updated content",
+            new_title: "Title two",
+            new_content: "Content two",
+          },
+        }
+        expect(response).to render_template(:show_split)
+        expect(response.body).to include("Updated title one")
+        expect(response.body).to include("Updated content")
+        expect(response.body).to include("Title two")
+        expect(response.body).to include("Content two")
+
+        expect(CourseLessonPart.count).to eq(1)
+        course_lesson_part.reload
+        expect(course_lesson_part.content).not_to include("Extra content")
+      end
+
       it "splits the lesson part and redirects to show" do
-        post "#{course_lesson_part_url}/split", params: { split_lesson_part_form: {
-          title: "Updated title one",
-          content: "Updated content",
-          new_title: "Title two",
-          new_content: "Content two",
-        } }
+        post "#{course_lesson_part_url}/split", params: {
+          commit: "Save changes",
+          split_lesson_part_form: {
+            title: "Updated title one",
+            content: "Updated content",
+            new_title: "Title two",
+            new_content: "Content two",
+          },
+        }
         expect(response).to redirect_to(course_lesson_part_url)
 
         expect(CourseLessonPart.count).to eq(2)
@@ -76,6 +100,25 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
         expect(course_lesson_part.content).to eq "Updated content"
         expect(course_lesson_part.next_lesson_part.title).to eq "Title two"
         expect(course_lesson_part.next_lesson_part.content).to eq "Content two"
+
+        post "#{course_lesson_part_url}/split", params: {
+          commit: "Save changes",
+          split_lesson_part_form: {
+            title: "Updated title one again",
+            content: "Updated content again",
+            new_title: "Title one point five",
+            new_content: "Content one point five",
+          },
+        }
+
+        expect(CourseLessonPart.count).to eq(3)
+        course_lesson_part.reload
+        expect(course_lesson_part.title).to eq "Updated title one again"
+        expect(course_lesson_part.content).to eq "Updated content again"
+        expect(course_lesson_part.next_lesson_part.title).to eq "Title one point five"
+        expect(course_lesson_part.next_lesson_part.content).to eq "Content one point five"
+        expect(course_lesson_part.next_lesson_part.next_lesson_part.title).to eq "Title two"
+        expect(course_lesson_part.next_lesson_part.next_lesson_part.content).to eq "Content two"
       end
     end
   end


### PR DESCRIPTION
### Context
Lessons are long. We want to split them.
Here is the UI to split them.

### Changes proposed in this pull request
1. Add a button and a page for splitting a lesson part.
2. Add endpoints for splitting a lesson part.
3. Add controller methods and policies for splitting a lesson part.

### Guidance to review
I haven't added lesson part navigation yet. That's next PR.

I opted to use more space than govuk pages use on the split page. That's because I think it is really convenient to see the old and new lesson part side-by-side. And for that, 960px that gov pages believe in, is too narrow. I intend to show it to Mark A (who will likely be the person who interacts with it the most) and see if he likes it.

![image](https://user-images.githubusercontent.com/42969249/109008926-cfa04280-76a5-11eb-9279-0de213a02df2.png)


### Testing
1. Not testing the presence of the button.
2. Tested with request tests (rspec).
3. Tested with request tests and unit tests (rspec).