### PR TITLE
Edit course lesson time

### DIFF
--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -22,9 +22,15 @@ class CoreInductionProgramme::LessonsController < ApplicationController
   def edit; end
 
   def update
-    @course_lesson.save!
-    flash[:success] = "Your changes have been saved"
-    redirect_to cip_year_module_lesson_url
+    @course_lesson.assign_attributes(course_lesson_params)
+
+    if @course_lesson.valid?
+      @course_lesson.update!(course_lesson_params)
+      flash[:success] = "Your changes have been saved"
+      redirect_to cip_year_module_lesson_url
+    else
+      render action: "edit"
+    end
   end
 
 private
@@ -32,10 +38,9 @@ private
   def load_course_lesson
     @course_lesson = CourseLesson.find(params[:id])
     authorize @course_lesson
-    @course_lesson.assign_attributes(course_lesson_params)
   end
 
   def course_lesson_params
-    params.permit(:title)
+    params.require(:course_lesson).permit(:title, :completion_time_in_minutes)
   end
 end

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -24,8 +24,7 @@ class CoreInductionProgramme::LessonsController < ApplicationController
   def update
     @course_lesson.assign_attributes(course_lesson_params)
 
-    if @course_lesson.valid?
-      @course_lesson.update!(course_lesson_params)
+    if @course_lesson.update(course_lesson_params)
       flash[:success] = "Your changes have been saved"
       redirect_to cip_year_module_lesson_url
     else

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -22,8 +22,6 @@ class CoreInductionProgramme::LessonsController < ApplicationController
   def edit; end
 
   def update
-    @course_lesson.assign_attributes(course_lesson_params)
-
     if @course_lesson.update(course_lesson_params)
       flash[:success] = "Your changes have been saved"
       redirect_to cip_year_module_lesson_url

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -14,11 +14,26 @@ class CourseLesson < ApplicationRecord
   has_many :course_lesson_parts
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
+  validates :completion_time_in_minutes, numericality: { greater_than_or_equal_to: 1, allow_nil: true, message: "Enter a number greater than 0" }
 
   attr_accessor :progress
 
   def course_lesson_parts_in_order
     preloaded_parts = course_lesson_parts.includes(:previous_lesson_part, :next_lesson_part)
     elements_in_order(elements: preloaded_parts, previous_method_name: :previous_lesson_part)
+  end
+
+  def convert_minutes_to_words(minutes_in_time)
+    number_of_hours = minutes_in_time / 60
+    number_of_minutes = minutes_in_time % 60
+
+    hour = "hour".pluralize(number_of_hours)
+    minute = "minute".pluralize(number_of_minutes)
+
+    if number_of_hours.positive?
+      "#{number_of_hours} #{hour} #{number_of_minutes} #{minute}"
+    else
+      "#{number_of_minutes} #{minute}"
+    end
   end
 end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -23,17 +23,17 @@ class CourseLesson < ApplicationRecord
     elements_in_order(elements: preloaded_parts, previous_method_name: :previous_lesson_part)
   end
 
-  def completion_time_in_words(minutes_in_time)
-    number_of_hours = minutes_in_time / 60
-    number_of_minutes = minutes_in_time % 60
+  def duration_in_minutes_in_words
+    number_of_hours = completion_time_in_minutes / 60
+    number_of_minutes = completion_time_in_minutes % 60
 
-    hour = "hour".pluralize(number_of_hours)
-    minute = "minute".pluralize(number_of_minutes)
+    hour_string = "hour".pluralize(number_of_hours)
+    minute_string = "minute".pluralize(number_of_minutes)
 
     if number_of_hours.positive?
-      "#{number_of_hours} #{hour} #{number_of_minutes} #{minute}"
+      "#{number_of_hours} #{hour_string} #{number_of_minutes} #{minute_string}"
     else
-      "#{number_of_minutes} #{minute}"
+      "#{number_of_minutes} #{minute_string}"
     end
   end
 end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -14,7 +14,7 @@ class CourseLesson < ApplicationRecord
   has_many :course_lesson_parts
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
-  validates :completion_time_in_minutes, numericality: { greater_than_or_equal_to: 1, allow_nil: true, message: "Enter a number greater than 0" }
+  validates :completion_time_in_minutes, numericality: { greater_than: 0, allow_nil: true, message: "Enter a number greater than 0" }
 
   attr_accessor :progress
 
@@ -23,7 +23,7 @@ class CourseLesson < ApplicationRecord
     elements_in_order(elements: preloaded_parts, previous_method_name: :previous_lesson_part)
   end
 
-  def convert_minutes_to_words(minutes_in_time)
+  def completion_time_in_words(minutes_in_time)
     number_of_hours = minutes_in_time / 60
     number_of_minutes = minutes_in_time % 60
 

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -8,10 +8,14 @@
     <% if policy(@course_lesson_part).edit? %>
       <%= link_to "Edit lesson content", edit_cip_year_module_lesson_part_path(@course_lesson_part), class: "govuk-button" %>
     <% end %>
-
     <h1 class="govuk-heading-xl"> <%= @course_lesson_part.course_lesson.title %></h1>
     <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
-
+    <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>
+    <h2 class="govuk-caption-m">
+      Duration: <%= @course_lesson_part.course_lesson.convert_minutes_to_words(
+                      @course_lesson_part.course_lesson.completion_time_in_minutes) %>
+    </h2>
+     <% end %>
     <div class="gem-c-govspeak govuk-govspeak ">
       <%= @course_lesson_part.content_to_html.html_safe %>
     </div>

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -1,28 +1,22 @@
 <%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
     <% if policy(@course_lesson_part.course_lesson).edit? %>
       <%= link_to "Edit lesson", edit_cip_year_module_lesson_path(id: @course_lesson_part.course_lesson.id), class: "govuk-button" %>
     <% end %>
     <% if policy(@course_lesson_part).edit? %>
       <%= link_to "Edit lesson content", edit_cip_year_module_lesson_part_path(@course_lesson_part), class: "govuk-button" %>
     <% end %>
-
-    <h1 class="govuk-heading-xl lesson-heading"> <%= @course_lesson_part.course_lesson.title %></h1>
-
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"> <%= @course_lesson_part.course_lesson.title %></h1>
     <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>
-      <h2 class="govuk-caption-m duration">
+      <h2 class="govuk-caption-m govuk-!-margin-bottom-8">
         Duration: <%= @course_lesson_part.course_lesson.duration_in_minutes_in_words %>
       </h2>
     <% end %>
-
     <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
-
     <div class="gem-c-govspeak govuk-govspeak">
       <%= @course_lesson_part.content_to_html.html_safe %>
     </div>
-
     <% if policy(@course_lesson_part.course_lesson).set_progress? %>
       <%= form_with url: cip_year_module_lesson_progress_path(lesson_id: @course_lesson_part.course_lesson.id), method: :put do |f| %>
         <%= f.govuk_collection_check_boxes(
@@ -34,6 +28,5 @@
         <%= f.govuk_submit "Complete session" %>
       <% end %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -9,14 +9,16 @@
       <%= link_to "Edit lesson content", edit_cip_year_module_lesson_part_path(@course_lesson_part), class: "govuk-button" %>
     <% end %>
 
-    <h1 class="govuk-heading-xl"> <%= @course_lesson_part.course_lesson.title %></h1>
-    <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
+    <h1 class="govuk-heading-xl lesson-heading"> <%= @course_lesson_part.course_lesson.title %></h1>
 
     <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>
-      <h2 class="govuk-caption-m">
-        Duration: <%= @course_lesson_part.course_lesson.completion_time_in_words(@course_lesson_part.course_lesson.completion_time_in_minutes) %>
+      <h2 class="govuk-caption-m duration">
+        Duration: <%= @course_lesson_part.course_lesson.duration_in_minutes_in_words %>
       </h2>
     <% end %>
+
+    <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
+
     <div class="gem-c-govspeak govuk-govspeak">
       <%= @course_lesson_part.content_to_html.html_safe %>
     </div>

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -8,15 +8,16 @@
     <% if policy(@course_lesson_part).edit? %>
       <%= link_to "Edit lesson content", edit_cip_year_module_lesson_part_path(@course_lesson_part), class: "govuk-button" %>
     <% end %>
+
     <h1 class="govuk-heading-xl"> <%= @course_lesson_part.course_lesson.title %></h1>
     <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
+
     <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>
-    <h2 class="govuk-caption-m">
-      Duration: <%= @course_lesson_part.course_lesson.convert_minutes_to_words(
-                      @course_lesson_part.course_lesson.completion_time_in_minutes) %>
-    </h2>
-     <% end %>
-    <div class="gem-c-govspeak govuk-govspeak ">
+      <h2 class="govuk-caption-m">
+        Duration: <%= @course_lesson_part.course_lesson.completion_time_in_words(@course_lesson_part.course_lesson.completion_time_in_minutes) %>
+      </h2>
+    <% end %>
+    <div class="gem-c-govspeak govuk-govspeak">
       <%= @course_lesson_part.content_to_html.html_safe %>
     </div>
 

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -1,6 +1,7 @@
 <%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
     <% if policy(@course_lesson_part.course_lesson).edit? %>
       <%= link_to "Edit lesson", edit_cip_year_module_lesson_path(id: @course_lesson_part.course_lesson.id), class: "govuk-button" %>
     <% end %>
@@ -10,17 +11,19 @@
     <% if policy(@course_lesson_part).show_split? %>
       <%= link_to "Split lesson content", cip_year_module_lesson_part_split_path(part_id: @course_lesson_part.id), class: "govuk-button" %>
     <% end %>
+
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"> <%= @course_lesson_part.course_lesson.title %></h1>
     <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>
       <h2 class="govuk-caption-m govuk-!-margin-bottom-8">
         Duration: <%= @course_lesson_part.course_lesson.duration_in_minutes_in_words %>
       </h2>
     <% end %>
-    <h1 class="govuk-heading-xl"> <%= @course_lesson_part.course_lesson.title %></h1>
+
     <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
     <div class="gem-c-govspeak govuk-govspeak">
       <%= @course_lesson_part.content_to_html.html_safe %>
     </div>
+
     <% if policy(@course_lesson_part.course_lesson).set_progress? %>
       <%= form_with url: cip_year_module_lesson_progress_path(lesson_id: @course_lesson_part.course_lesson.id), method: :put do |f| %>
         <%= f.govuk_collection_radio_buttons(

--- a/app/views/core_induction_programme/lessons/edit.html.erb
+++ b/app/views/core_induction_programme/lessons/edit.html.erb
@@ -2,8 +2,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Edit lesson</h1>
-    <%= form_with url: cip_year_module_lesson_path, method: :put do |f| %>
+    <%= form_with model: @course_lesson, url: cip_year_module_lesson_path, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :title, label: { text: "Lesson title" }, value: @course_lesson.title %>
+      <%= f.govuk_number_field :completion_time_in_minutes, label: { text: "Time in minutes"}, width: 4,
+                               hint: { text: " For example, 90"}, value: @course_lesson.completion_time_in_minutes %>
       <%= f.govuk_submit "Save changes" %>
     <% end %>
   </div>

--- a/app/views/core_induction_programme/lessons/edit.html.erb
+++ b/app/views/core_induction_programme/lessons/edit.html.erb
@@ -5,8 +5,11 @@
     <%= form_with model: @course_lesson, url: cip_year_module_lesson_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :title, label: { text: "Lesson title" }, value: @course_lesson.title %>
-      <%= f.govuk_number_field :completion_time_in_minutes, label: { text: "Time in minutes"}, width: 4,
-                               hint: { text: " For example, 90"}, value: @course_lesson.completion_time_in_minutes %>
+      <%= f.govuk_number_field(
+            :completion_time_in_minutes,
+            label: { text: "Time in minutes"},
+            width: 4, hint: { text: " For example, 90"},
+            value: @course_lesson.completion_time_in_minutes) %>
       <%= f.govuk_submit "Save changes" %>
     <% end %>
   </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -6,9 +6,10 @@
     <% end %>
     <h1 class="govuk-heading-xl"> <%= @course_lesson.title %></h1>
     <% if @course_lesson.completion_time_in_minutes %>
-    <h1 class="govuk-heading-m">Duration: <%= @course_lesson.convert_minutes_to_words(
-                                       @course_lesson.completion_time_in_minutes) %></h1>
-      <% end %>
+      <h2 class="govuk-heading-m duration">
+        Duration: <%= @course_lesson.completion_time_in_words(@course_lesson.completion_time_in_minutes) %>
+      </h2>
+    <% end %>
     <p>This lesson has no content!</p>
   </div>
 </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -6,7 +6,7 @@
     <% end %>
 
     <% if @course_lesson.completion_time_in_minutes %>
-      <h2 class="govuk-heading-m duration">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-8">
         Duration: <%= @course_lesson.duration_in_minutes_in_words %>
       </h2>
     <% end %>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -5,6 +5,10 @@
       <%= link_to "Edit lesson", edit_cip_year_module_lesson_path(id: @course_lesson.id), class: "govuk-button" %>
     <% end %>
     <h1 class="govuk-heading-xl"> <%= @course_lesson.title %></h1>
+    <% if @course_lesson.completion_time_in_minutes %>
+    <h1 class="govuk-heading-m">Duration: <%= @course_lesson.convert_minutes_to_words(
+                                       @course_lesson.completion_time_in_minutes) %></h1>
+      <% end %>
     <p>This lesson has no content!</p>
   </div>
 </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -4,12 +4,14 @@
     <% if policy(@course_lesson).edit? %>
       <%= link_to "Edit lesson", edit_cip_year_module_lesson_path(id: @course_lesson.id), class: "govuk-button" %>
     <% end %>
-    <h1 class="govuk-heading-xl"> <%= @course_lesson.title %></h1>
+
     <% if @course_lesson.completion_time_in_minutes %>
       <h2 class="govuk-heading-m duration">
-        Duration: <%= @course_lesson.completion_time_in_words(@course_lesson.completion_time_in_minutes) %>
+        Duration: <%= @course_lesson.duration_in_minutes_in_words %>
       </h2>
     <% end %>
+
+    <h1 class="govuk-heading-xl"> <%= @course_lesson.title %></h1>
     <p>This lesson has no content!</p>
   </div>
 </div>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -14,9 +14,12 @@
         <ul class="app-task-list__items">
           <% if @course_lessons_with_progress.each do |lesson| %>
             <li class="app-task-list__item">
-              <span>
+              <div>
                 <%= govuk_link_to lesson.title, cip_year_module_lesson_path(@course_module.course_year, @course_module, lesson) %>
-              </span>
+                <% if lesson.completion_time_in_minutes %>
+                <p>Duration: <%= lesson.convert_minutes_to_words(lesson.completion_time_in_minutes) %></p>
+                  <% end %>
+              </div>
               <%= render ProgressLabelComponent.new progress: lesson.progress %>
             </li>
           <% end.empty? %>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -17,7 +17,7 @@
               <div>
                 <%= govuk_link_to lesson.title, cip_year_module_lesson_path(@course_module.course_year, @course_module, lesson) %>
                 <% if lesson.completion_time_in_minutes %>
-                  <p>Duration: <%= lesson.completion_time_in_words(lesson.completion_time_in_minutes) %></p>
+                  <p>Duration: <%= lesson.duration_in_minutes_in_words %></p>
                 <% end %>
               </div>
               <%= render ProgressLabelComponent.new progress: lesson.progress %>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -17,8 +17,8 @@
               <div>
                 <%= govuk_link_to lesson.title, cip_year_module_lesson_path(@course_module.course_year, @course_module, lesson) %>
                 <% if lesson.completion_time_in_minutes %>
-                <p>Duration: <%= lesson.convert_minutes_to_words(lesson.completion_time_in_minutes) %></p>
-                  <% end %>
+                  <p>Duration: <%= lesson.completion_time_in_words(lesson.completion_time_in_minutes) %></p>
+                <% end %>
               </div>
               <%= render ProgressLabelComponent.new progress: lesson.progress %>
             </li>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -16,5 +16,5 @@ $govuk-image-url-function: frontend-image-url;
 @import "pagination";
 @import "page-tabs";
 @import "~accessible-autocomplete";
-
+@import "course_lesson";
 @import "govspeak";

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -16,5 +16,4 @@ $govuk-image-url-function: frontend-image-url;
 @import "pagination";
 @import "page-tabs";
 @import "~accessible-autocomplete";
-@import "course_lesson";
 @import "govspeak";

--- a/app/webpacker/styles/course_lesson.scss
+++ b/app/webpacker/styles/course_lesson.scss
@@ -1,0 +1,7 @@
+.duration h2 {
+  margin-bottom: 50px;
+}
+
+.lesson-heading {
+  margin-bottom: 20px;
+}

--- a/app/webpacker/styles/course_lesson.scss
+++ b/app/webpacker/styles/course_lesson.scss
@@ -1,7 +1,0 @@
-.duration h2 {
-  margin-bottom: 50px;
-}
-
-.lesson-heading {
-  margin-bottom: 20px;
-}

--- a/db/migrate/20210224162240_add_completion_time_in_minutes_to_course_lessons.rb
+++ b/db/migrate/20210224162240_add_completion_time_in_minutes_to_course_lessons.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCompletionTimeInMinutesToCourseLessons < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_lessons, :completion_time_in_minutes, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_143611) do
+ActiveRecord::Schema.define(version: 2021_02_24_162240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2021_02_18_143611) do
     t.uuid "previous_lesson_id"
     t.uuid "course_module_id", null: false
     t.integer "version", default: 1, null: false
+    t.integer "completion_time_in_minutes"
     t.index ["course_module_id"], name: "index_course_lessons_on_course_module_id"
     t.index ["previous_lesson_id"], name: "index_course_lessons_on_previous_lesson_id"
   end

--- a/spec/cypress/integration/cip-stories-admin.js
+++ b/spec/cypress/integration/cip-stories-admin.js
@@ -60,7 +60,7 @@ describe("Admin user interaction with Core Induction Programme", () => {
       cy.get("a.govuk-button").contains("Edit lesson").click();
 
       cy.get("h1").should("contain", "Edit lesson");
-      cy.get("input[name='title']").type("New title");
+      cy.get("input[name='course_lesson[title]']").type("New title");
       cy.contains("Save changes").click();
 
       cy.get("h1").should("contain", "New title");

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe CourseLesson, type: :model do
     subject { FactoryBot.create(:course_lesson) }
     it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
     it { is_expected.to validate_length_of(:title).is_at_most(255) }
-    it { is_expected.to validate_numericality_of(:completion_time_in_minutes).is_greater_than_or_equal_to(1).with_message("Enter a number greater than 0") }
+    it { is_expected.to validate_numericality_of(:completion_time_in_minutes).is_greater_than(0).with_message("Enter a number greater than 0") }
   end
 end

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -26,4 +26,25 @@ RSpec.describe CourseLesson, type: :model do
     it { is_expected.to validate_length_of(:title).is_at_most(255) }
     it { is_expected.to validate_numericality_of(:completion_time_in_minutes).is_greater_than(0).with_message("Enter a number greater than 0") }
   end
+
+  describe ".duration_in_minutes_in_words" do
+    before :each do
+      @course_lesson = FactoryBot.create(:course_lesson)
+    end
+
+    it "returns an integer < 60 converted to words showing just minutes" do
+      @course_lesson.completion_time_in_minutes = 55
+      expect(@course_lesson.duration_in_minutes_in_words).to eql("55 minutes")
+    end
+
+    it "returns an integer > 59 & < 120 converted to words showing the singular of hour and minute" do
+      @course_lesson.completion_time_in_minutes = 61
+      expect(@course_lesson.duration_in_minutes_in_words).to eql("1 hour 1 minute")
+    end
+
+    it "returns hours and minutes pluralized" do
+      @course_lesson.completion_time_in_minutes = 122
+      expect(@course_lesson.duration_in_minutes_in_words).to eql("2 hours 2 minutes")
+    end
+  end
 end

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CourseLesson, type: :model do
       CourseLesson.create(
         title: "Test Course lesson",
         course_module: FactoryBot.create(:course_module),
+        completion_time_in_minutes: 10,
       )
     }.to change { CourseLesson.count }.by(1)
   end
@@ -23,5 +24,6 @@ RSpec.describe CourseLesson, type: :model do
     subject { FactoryBot.create(:course_lesson) }
     it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
     it { is_expected.to validate_length_of(:title).is_at_most(255) }
+    it { is_expected.to validate_numericality_of(:completion_time_in_minutes).is_greater_than_or_equal_to(1).with_message("Enter a number greater than 0") }
   end
 end

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -38,10 +38,21 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
 
     describe "PUT /core-induction-programme/years/:years/modules/:modules/lessons/:lessons" do
       it "redirects to the lesson page when saving title" do
-        put course_lesson_url, params: { commit: "Save changes", title: "New title" }
+        put course_lesson_url, params: { course_lesson: { commit: "Save changes", title: "New title" } }
         expect(response).to redirect_to(course_lesson_url)
         get course_lesson_url
         expect(response.body).to include("New title")
+      end
+      it "redirects to the lesson page when saving minutes" do
+        put course_lesson_url, params: { course_lesson: { commit: "Save changes", completion_time_in_minutes: 80 } }
+        expect(response).to redirect_to(course_lesson_url)
+        get course_lesson_url
+        expect(response.body).to include("Duration: 1 hour 20 minutes")
+      end
+      it "renders the error page with an error when an invalid number is inputted" do
+        put course_lesson_url, params: { course_lesson: { commit: "Save changes", completion_time_in_minutes: -10 } }
+        expect(response).to render_template(:edit)
+        expect(response.body).to include("Enter a number greater than 0")
       end
     end
   end

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -43,12 +43,14 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
         get course_lesson_url
         expect(response.body).to include("New title")
       end
+
       it "redirects to the lesson page when saving minutes" do
         put course_lesson_url, params: { course_lesson: { commit: "Save changes", completion_time_in_minutes: 80 } }
         expect(response).to redirect_to(course_lesson_url)
         get course_lesson_url
         expect(response.body).to include("Duration: 1 hour 20 minutes")
       end
+
       it "renders the error page with an error when an invalid number is inputted" do
         put course_lesson_url, params: { course_lesson: { commit: "Save changes", completion_time_in_minutes: -10 } }
         expect(response).to render_template(:edit)


### PR DESCRIPTION
### Context
Course lessons need to be able to have the duration time set and edited. This will be done by DfE admin

### Changes proposed in this pull request
`e21a83f` - Updates to the db with a migration and schema, add completion_time_in_minutes to course_lessons
`5b0e2b1` and `8053036` - Changes to the models and controllers.
`ce829ed` Updates to relevant views - Duration now shows in the course_module#show, course_lesson#show and #edit, and course_lesson_parts#show

### Guidance to review
Converting minutes is a bit clunky in the CL model. Also, I couldn't see a way to add + only integers in the migration so have just done validations in the model. 

**Stylings** have been added but i am not 100% on what the convention is for customising them. They've not been added to course module because i felt they were being displayed as shown on Dom's [figma](url) 

### Testing
Updated specs for CourseLesson model and CourseLesson requests

<img width="978" alt="Screenshot 2021-02-26 at 08 18 58" src="https://user-images.githubusercontent.com/69353998/109274477-7520f680-780b-11eb-800d-b345261a6b4c.png">

