### PR TITLE
Add discussion needed progress status

### DIFF
--- a/app/components/progress_label_component.rb
+++ b/app/components/progress_label_component.rb
@@ -14,6 +14,8 @@ private
       "govuk-tag--grey"
     when "in_progress"
       "govuk-tag--blue"
+    when "discussion_needed"
+      "govuk-tag--orange"
     else
       ""
     end

--- a/app/controllers/core_induction_programme/progress_controller.rb
+++ b/app/controllers/core_induction_programme/progress_controller.rb
@@ -12,8 +12,8 @@ class CoreInductionProgramme::ProgressController < ApplicationController
     progress = CourseLessonProgress.find_or_create_by!(early_career_teacher_profile: @current_user.early_career_teacher_profile, course_lesson: @course_lesson)
     authorize progress
     if @current_user.early_career_teacher?
-      if params[:progress].include?("complete")
-        progress.complete!
+      unless params[:progress].include?("not_started")
+        progress.update!(progress: params[:progress])
       end
     end
     redirect_to cip_year_module_url(id: @course_lesson.course_module.id)

--- a/app/models/course_lesson_progress.rb
+++ b/app/models/course_lesson_progress.rb
@@ -4,6 +4,7 @@ class CourseLessonProgress < ApplicationRecord
   enum progress: {
     not_started: "not_started",
     in_progress: "in_progress",
+    discussion_needed: "discussion_needed",
     complete: "complete",
   }
 

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -21,13 +21,20 @@
 
     <% if policy(@course_lesson_part.course_lesson).set_progress? %>
       <%= form_with url: cip_year_module_lesson_progress_path(lesson_id: @course_lesson_part.course_lesson.id), method: :put do |f| %>
-        <%= f.govuk_collection_check_boxes(
+        <%= f.govuk_collection_radio_buttons(
               :progress,
-              [OpenStruct.new(id: :complete, name: "I feel confident that I've read and understood this session")],
+              [
+                OpenStruct.new(id: :complete, name: "I feel confident that I’ve read and understood this session"),
+                OpenStruct.new(id: :in_progress, name: "I would like more time on this session and will revisit"),
+                OpenStruct.new(id: :discussion_needed, name: "There are sections that I don’t understand and would like to discuss with my mentor"),
+              ],
               :id,
               :name,
               legend: {text: "That's the end of this session"}) %>
-        <%= f.govuk_submit "Complete session" %>
+
+        <p class="govuk-body">Once you click End Session your reflections will be able to view via the self study dashboard. Your mentor will also be able to access these ahead of your weekly meetings also.</p>
+
+        <%= f.govuk_submit "End session" %>
       <% end %>
     <% end %>
 

--- a/spec/cypress/integration/cip-stories-early-career-teacher.js
+++ b/spec/cypress/integration/cip-stories-early-career-teacher.js
@@ -54,16 +54,27 @@ describe("ECT user interaction with Core Induction Programme", () => {
 
     cy.get("@courseLesson").then(([lesson]) => {
       cy.visitModuleOfLesson(lesson);
-      cy.contains("strong.govuk-tag", "not started");
-
-      cy.visitLesson(lesson);
-      cy.visitModuleOfLesson(lesson);
-      cy.contains("strong.govuk-tag", "in progress");
-
-      cy.visitLesson(lesson);
-      cy.get('[type="checkbox"]').check();
-      cy.get("form").submit();
-      cy.contains("strong.govuk-tag", "complete");
     });
+
+    cy.contains(".govuk-tag", "not started");
+
+    cy.contains("Test Course lesson").click();
+    cy.go("back");
+    cy.contains(".govuk-tag", "in progress");
+
+    cy.contains("Test Course lesson").click();
+    cy.get('[for="progress-discussion-needed-field"]').click();
+    cy.get('[name="commit"]').contains("End session").click();
+    cy.contains(".govuk-tag", "discussion needed");
+
+    cy.contains("Test Course lesson").click();
+    cy.get('[for="progress-in-progress-field"]').click();
+    cy.get('[name="commit"]').contains("End session").click();
+    cy.contains(".govuk-tag", "in progress");
+
+    cy.contains("Test Course lesson").click();
+    cy.get('[for="progress-complete-field"]').click();
+    cy.get('[name="commit"]').contains("End session").click();
+    cy.contains(".govuk-tag", "complete");
   });
 });

--- a/spec/requests/core_induction_programme/progress_spec.rb
+++ b/spec/requests/core_induction_programme/progress_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe "Core Induction Programme Progress", type: :request do
 
     describe "PUT /core-induction-programme/years/:years/modules/:modules/lessons/:lessons/progress" do
       it "updates the progress of an ECT" do
-        put progress_url, params: { progress: ["", "complete"] }
+        put progress_url, params: { progress: "complete" }
         expect(progress).to eq("complete")
       end
 
       it "redirects to module when changing progress" do
-        put progress_url, params: { progress: ["", "complete"] }
+        put progress_url, params: { progress: "complete" }
         expect(response).to redirect_to("/core-induction-programme/years/#{course_lesson.course_module.course_year.id}/modules/#{course_lesson.course_module.id}")
       end
 
       it "redirects to module when not changing progress" do
-        put progress_url, params: { progress: [""] }
+        put progress_url, params: { progress: "" }
         expect(response).to redirect_to("/core-induction-programme/years/#{course_lesson.course_module.course_year.id}/modules/#{course_lesson.course_module.id}")
       end
     end


### PR DESCRIPTION
### Context

https://trello.com/c/iPgtIa2T/164-update-progress-setting-to-radios

### Changes proposed in this pull request

- Add "discussion needed" status to lesson progress
- Turn previous checkbox into radios with multiple options for ECTs

### Guidance to review

My ruby might be in need of improvement!