### PR TITLE
Add current page user is visiting to breadcrumbs

### DIFF
--- a/app/helpers/cip_breadcrumb_helper.rb
+++ b/app/helpers/cip_breadcrumb_helper.rb
@@ -1,22 +1,30 @@
 # frozen_string_literal: true
 
 module CipBreadcrumbHelper
-  def course_year_breadcrumbs(user)
-    [home_crumb(user)]
+  def course_year_breadcrumbs(user, course_year)
+    year_crumb = course_year_crumb(course_year)
+    [
+      home_crumb(user),
+      end_crumb(year_crumb),
+    ]
   end
 
   def course_module_breadcrumbs(user, course_module)
+    module_crumb = course_module_crumb(course_module)
     [
       home_crumb(user),
-      course_module_crumb(course_module),
+      course_year_crumb(course_module.course_year),
+      end_crumb(module_crumb),
     ]
   end
 
   def course_lesson_breadcrumbs(user, course_lesson)
+    lesson_crumb = course_lesson_crumb(course_lesson)
     [
       home_crumb(user),
+      course_year_crumb(course_lesson.course_module.course_year),
       course_module_crumb(course_lesson.course_module),
-      course_lesson_crumb(course_lesson),
+      end_crumb(lesson_crumb),
     ]
   end
 
@@ -26,11 +34,19 @@ private
     ["Home", user ? dashboard_path : cip_path]
   end
 
+  def course_year_crumb(course_year)
+    [course_year.title, cip_year_path(course_year)]
+  end
+
   def course_module_crumb(course_module)
-    [course_module.course_year.title, cip_year_path(course_module.course_year)]
+    [course_module.title, cip_year_module_path(course_module.course_year, course_module)]
   end
 
   def course_lesson_crumb(course_lesson)
-    [course_lesson.course_module.title, cip_year_module_path(course_lesson.course_module.course_year, course_lesson.course_module)]
+    [course_lesson.title, cip_year_module_lesson_path(course_lesson.course_module.course_year, course_lesson.course_module, course_lesson)]
+  end
+
+  def end_crumb(crumb)
+    action_name == "show" ? crumb[0] : crumb
   end
 end

--- a/app/views/core_induction_programme/years/edit.html.erb
+++ b/app/views/core_induction_programme/years/edit.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user) %>
+<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user, @course_year) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user) %>
+<%= govuk_breadcrumbs breadcrumbs: course_year_breadcrumbs(@current_user, @course_year) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if policy(@course_year).edit? %>

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CipBreadcrumbHelper do
+  describe "core-induction-programme" do
+    let(:user) { create(:user, :admin) }
+    let(:course_year) { create(:course_year) }
+    let(:course_module) { create(:course_module, course_year: course_year) }
+    let(:course_lesson) { create(:course_lesson, course_module: course_module) }
+
+    it "returns an array for the course year breadcrumb" do
+      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
+
+      course_year_crumb = [["Home", "/dashboard"], [course_year.title, "/core-induction-programme/years/#{course_year.id}"]]
+
+      expect(course_year_breadcrumb).to eq(course_year_crumb)
+    end
+
+    it "returns an array for the course module breadcrumb" do
+      course_module_breadcrumb = helper.course_module_breadcrumbs(user, course_module)
+
+      course_year_crumb = [course_year.title, "/core-induction-programme/years/#{course_year.id}"]
+      course_module_crumb = [course_module.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}"]
+
+      expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], course_year_crumb, course_module_crumb])
+    end
+
+    it "returns an array for the course lesson breadcrumb" do
+      course_lesson_breadcrumb = helper.course_lesson_breadcrumbs(user, course_lesson)
+
+      course_year_crumb = [course_year.title, "/core-induction-programme/years/#{course_year.id}"]
+      course_module_crumb = [course_module.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}"]
+      course_lesson_crumb = [course_lesson.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}/lessons/#{course_lesson.id}"]
+
+      expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], course_year_crumb, course_module_crumb, course_lesson_crumb])
+    end
+  end
+end

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -2,56 +2,69 @@
 
 require "rails_helper"
 
-describe CipBreadcrumbHelper do
-  describe "core-induction-programme" do
-    let(:user) { create(:user, :admin) }
-    let(:course_year) { create(:course_year) }
-    let(:course_module) { create(:course_module, course_year: course_year) }
-    let(:course_lesson) { create(:course_lesson, course_module: course_module) }
+describe CipBreadcrumbHelper, type: :helper do
+  before :each do
+    @user = FactoryBot.create(:user, :admin)
+    @course_year = FactoryBot.create(:course_year)
+    @course_year_crumb = [@course_year.title, "/core-induction-programme/years/#{@course_year.id}"]
+  end
 
+  describe "#year_breadcrumb" do
+    let(:course_year_breadcrumb) { helper.course_year_breadcrumbs(@user, @course_year) }
     it "returns an array for the course year breadcrumb" do
-      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
-
-      course_year_crumb = [["Home", "/dashboard"], [course_year.title, "/core-induction-programme/years/#{course_year.id}"]]
-
-      expect(course_year_breadcrumb).to eq(course_year_crumb)
+      expect(course_year_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb])
     end
+
+    it "returns a url for the end crumb when the action_name is edit" do
+      allow(helper).to receive(:action_name) { "edit" }
+      expect(course_year_breadcrumb).to eql([["Home", "/dashboard"], @course_year_crumb])
+    end
+
+    it "returns just the title for the end crumb when the action_name is show" do
+      allow(helper).to receive(:action_name) { "show" }
+      expect(course_year_breadcrumb).to eql([["Home", "/dashboard"], @course_year.title])
+    end
+  end
+
+  describe "#module_breadcrumb" do
+    let(:course_module) { create(:course_module, course_year: @course_year) }
+    let(:course_module_crumb) { [course_module.title, "/core-induction-programme/years/#{@course_year.id}/modules/#{course_module.id}"] }
+    let(:course_module_breadcrumb) { helper.course_module_breadcrumbs(@user, course_module) }
 
     it "returns an array for the course module breadcrumb" do
-      course_module_breadcrumb = helper.course_module_breadcrumbs(user, course_module)
-
-      course_year_crumb = [course_year.title, "/core-induction-programme/years/#{course_year.id}"]
-      course_module_crumb = [course_module.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}"]
-
-      expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], course_year_crumb, course_module_crumb])
+      expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb, course_module_crumb])
     end
+
+    it "returns a url for the end crumb when the action_name is edit" do
+      allow(helper).to receive(:action_name) { "edit" }
+      expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb, course_module_crumb])
+    end
+
+    it "returns just the title for the end crumb when the action_name is show" do
+      allow(helper).to receive(:action_name) { "show" }
+      expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], @course_year_crumb, course_module.title])
+    end
+  end
+
+  describe "#lesson_breadcrumb" do
+    let(:course_module) { create(:course_module, course_year: @course_year) }
+    let(:course_lesson) { create(:course_lesson, course_module: course_module) }
+    let(:course_module_crumb) { [course_module.title, "/core-induction-programme/years/#{@course_year.id}/modules/#{course_module.id}"] }
+    let(:course_lesson_crumb) { [course_lesson.title, "/core-induction-programme/years/#{@course_year.id}/modules/#{course_module.id}/lessons/#{course_lesson.id}"] }
+    let(:course_lesson_breadcrumb) { helper.course_lesson_breadcrumbs(@user, course_lesson) }
 
     it "returns an array for the course lesson breadcrumb" do
-      course_lesson_breadcrumb = helper.course_lesson_breadcrumbs(user, course_lesson)
-
-      course_year_crumb = [course_year.title, "/core-induction-programme/years/#{course_year.id}"]
-      course_module_crumb = [course_module.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}"]
-      course_lesson_crumb = [course_lesson.title, "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}/lessons/#{course_lesson.id}"]
-
-      expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], course_year_crumb, course_module_crumb, course_lesson_crumb])
+      expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb, course_module_crumb, course_lesson_crumb])
     end
 
-    it "returns a string for the end crumb when rendered the action_name is show" do
-      allow(helper).to receive(:action_name) { "show" }
-
-      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
-      course_year_crumb = [["Home", "/dashboard"], "Test Course year"]
-
-      expect(course_year_breadcrumb).to eql(course_year_crumb)
-    end
-
-    it "returns the title and url for the end crumb when the action_name is edit" do
+    it "returns the url for the end crumb when the action_name is edit" do
       allow(helper).to receive(:action_name) { "edit" }
+      expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb, course_module_crumb, course_lesson_crumb])
+    end
 
-      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
-      course_year_crumb = [["Home", "/dashboard"], [course_year.title, "/core-induction-programme/years/#{course_year.id}"]]
-
-      expect(course_year_breadcrumb).to eql(course_year_crumb)
+    it "returns just the title for the end crumb when the action_name is show" do
+      allow(helper).to receive(:action_name) { "show" }
+      expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], @course_year_crumb, course_module_crumb, course_lesson.title])
     end
   end
 end

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -35,5 +35,23 @@ describe CipBreadcrumbHelper do
 
       expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], course_year_crumb, course_module_crumb, course_lesson_crumb])
     end
+
+    it "returns a string for the end crumb when rendered the action_name is show" do
+      allow(helper).to receive(:action_name) { "show" }
+
+      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
+      course_year_crumb = [["Home", "/dashboard"], "Test Course year"]
+
+      expect(course_year_breadcrumb).to eql(course_year_crumb)
+    end
+
+    it "returns the title and url for the end crumb when the action_name is edit" do
+      allow(helper).to receive(:action_name) { "edit" }
+
+      course_year_breadcrumb = helper.course_year_breadcrumbs(user, course_year)
+      course_year_crumb = [["Home", "/dashboard"], [course_year.title, "/core-induction-programme/years/#{course_year.id}"]]
+
+      expect(course_year_breadcrumb).to eql(course_year_crumb)
+    end
   end
 end


### PR DESCRIPTION
### Context
The existing breadcrumbs don't include the page that the user is currently on or allow the user to return to the show page when editing using the breadcrumbs.

### Changes proposed in this pull request
- updating breadcrumb helper to add breadcrumbs for course_year
- amending path of course_module and course_lesson breadcrumb 
- adding a method for the end crumb that shows either a link or string depending whether the user is on show or edit. As below 

### show - no link included in the end crumb
<img width="1099" alt="Screenshot 2021-03-02 at 13 49 55" src="https://user-images.githubusercontent.com/69353998/109658369-6d8c8500-7b5e-11eb-8d4e-a29db2821a4e.png">

### edit
<img width="1021" alt="Screenshot 2021-03-02 at 13 50 16" src="https://user-images.githubusercontent.com/69353998/109658363-6b2a2b00-7b5e-11eb-8ad1-60b5f1aa4b83.png">

### Guidance to review
Had a weird problem with 2 tests failing on course lesson parts. It's not been replicated in github or on Michals laptop. It sorted itself once the db was dropped and recreated. If this happens on others devices it could need further looking at. 

### Testing
Testing of breadcrumb helper, including testing for behaviour with show and edit actions.