### PR TITLE
Lesson part deletion

### DIFF
--- a/app/controllers/core_induction_programme/lesson_parts_controller.rb
+++ b/app/controllers/core_induction_programme/lesson_parts_controller.rb
@@ -48,6 +48,15 @@ class CoreInductionProgramme::LessonPartsController < ApplicationController
     render action: "show_split"
   end
 
+  def show_delete; end
+
+  def destroy
+    @course_lesson_part = CourseLessonPart.find(params[:id])
+    lesson = @course_lesson_part.course_lesson
+    @course_lesson_part.destroy!
+    redirect_to cip_year_module_lesson_path(id: lesson.id)
+  end
+
 private
 
   def load_course_lesson_part

--- a/app/models/course_lesson_part.rb
+++ b/app/models/course_lesson_part.rb
@@ -3,7 +3,7 @@
 class CourseLessonPart < ApplicationRecord
   belongs_to :course_lesson
 
-  has_one :next_lesson_part, class_name: "CourseLessonPart", foreign_key: :previous_lesson_part_id
+  has_one :next_lesson_part, class_name: "CourseLessonPart", foreign_key: :previous_lesson_part_id, dependent: :destroy
   belongs_to :previous_lesson_part, class_name: "CourseLessonPart", inverse_of: :next_lesson_part, optional: true
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }

--- a/app/models/course_lesson_part.rb
+++ b/app/models/course_lesson_part.rb
@@ -3,7 +3,7 @@
 class CourseLessonPart < ApplicationRecord
   belongs_to :course_lesson
 
-  has_one :next_lesson_part, class_name: "CourseLessonPart", foreign_key: :previous_lesson_part_id, dependent: :destroy
+  has_one :next_lesson_part, class_name: "CourseLessonPart", foreign_key: :previous_lesson_part_id, dependent: :nullify
   belongs_to :previous_lesson_part, class_name: "CourseLessonPart", inverse_of: :next_lesson_part, optional: true
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }

--- a/app/policies/course_lesson_part_policy.rb
+++ b/app/policies/course_lesson_part_policy.rb
@@ -25,4 +25,12 @@ class CourseLessonPartPolicy < ApplicationPolicy
   def split?
     update?
   end
+
+  def show_delete?
+    update?
+  end
+
+  def destroy?
+    update?
+  end
 end

--- a/app/policies/course_lesson_part_policy.rb
+++ b/app/policies/course_lesson_part_policy.rb
@@ -27,10 +27,10 @@ class CourseLessonPartPolicy < ApplicationPolicy
   end
 
   def show_delete?
-    update?
+    destroy?
   end
 
   def destroy?
-    update?
+    update? && @record.course_lesson.course_lesson_parts.length > 1
   end
 end

--- a/app/views/core_induction_programme/lesson_parts/edit.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/edit.html.erb
@@ -2,6 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
+    <%= govuk_link_to "Delete lesson part", cip_year_module_lesson_part_show_delete_path(part_id: @course_lesson_part.id), button: true, class: "govuk-button--secondary"  %>
     <%= form_with url: cip_year_module_lesson_part_path, method: :put do |f| %>
       <%= f.govuk_text_field :title, label: { text: "Lesson title" }, value: @course_lesson_part.title %>
       <%= f.govuk_text_area :content, label: { text: "Markdown string for course lesson content" }, rows: 10, value: @course_lesson_part.content %>

--- a/app/views/core_induction_programme/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show.html.erb
@@ -11,6 +11,9 @@
     <% if policy(@course_lesson_part).show_split? %>
       <%= govuk_link_to "Split lesson content", cip_year_module_lesson_part_split_path(part_id: @course_lesson_part.id), button: true %>
     <% end %>
+    <% if policy(@course_lesson_part).show_delete? %>
+      <%= govuk_link_to "Delete lesson part", cip_year_module_lesson_part_show_delete_path(part_id: @course_lesson_part.id), button: true, class: "govuk-button--secondary"  %>
+    <% end %>
 
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"> <%= @course_lesson_part.course_lesson.title %></h1>
     <% if @course_lesson_part.course_lesson.completion_time_in_minutes %>

--- a/app/views/core_induction_programme/lesson_parts/show_delete.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show_delete.html.erb
@@ -1,0 +1,17 @@
+<%= govuk_breadcrumbs breadcrumbs: course_lesson_breadcrumbs(@current_user, @course_lesson_part.course_lesson) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2>Confirm you would like to remove <i><%= @course_lesson_part.title %></i> from <%= @course_lesson_part.course_lesson.title %>.</h2>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <div class="govuk-warning-text__text">This lesson part can not be retrieved once it has been deleted.</div>
+      </div>
+    <p>You can return to <b><%= @course_lesson_part.course_lesson.title %></b> without making any changes by clicking cancel</p>
+    <div class="govuk-button-group">
+      <%= form_with url: cip_year_module_lesson_part_path(id: @course_lesson_part.id), method: :delete do |f| %>
+        <%= f.govuk_submit "Delete", warning: true %>
+        <%= govuk_link_to "Cancel", cip_year_module_lesson_part_path(id: @course_lesson_part.id), class: "govuk-!-margin-top-2"%>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/core_induction_programme/lesson_parts/show_delete.html.erb
+++ b/app/views/core_induction_programme/lesson_parts/show_delete.html.erb
@@ -2,10 +2,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h2>Confirm you would like to remove <i><%= @course_lesson_part.title %></i> from <%= @course_lesson_part.course_lesson.title %>.</h2>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <div class="govuk-warning-text__text">This lesson part can not be retrieved once it has been deleted.</div>
-      </div>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <div class="govuk-warning-text__text">This lesson part can not be retrieved once it has been deleted.</div>
+    </div>
     <p>You can return to <b><%= @course_lesson_part.course_lesson.title %></b> without making any changes by clicking cancel</p>
     <div class="govuk-button-group">
       <%= form_with url: cip_year_module_lesson_part_path(id: @course_lesson_part.id), method: :delete do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,9 +35,10 @@ Rails.application.routes.draw do
     resources :years, controller: "core_induction_programme/years", only: %i[show edit update] do
       resources :modules, controller: "core_induction_programme/modules", only: %i[show edit update] do
         resources :lessons, controller: "core_induction_programme/lessons", only: %i[show edit update] do
-          resources :parts, controller: "core_induction_programme/lesson_parts", only: %i[show edit update] do
+          resources :parts, controller: "core_induction_programme/lesson_parts", only: %i[show edit update destroy] do
             get "split", to: "core_induction_programme/lesson_parts#show_split", as: "split"
             post "split", to: "core_induction_programme/lesson_parts#split"
+            get "show_delete", to: "core_induction_programme/lesson_parts#show_delete"
           end
           resource :progress, controller: "core_induction_programme/progress", only: %i[update]
         end

--- a/spec/models/course_lesson_part_spec.rb
+++ b/spec/models/course_lesson_part_spec.rb
@@ -13,9 +13,14 @@ RSpec.describe CourseLessonPart, type: :model do
     }.to change { CourseLessonPart.count }.by(1)
   end
 
+  it "can be deleted" do
+    course_lesson_part = FactoryBot.create(:course_lesson_part)
+    expect { course_lesson_part.destroy }.to change { CourseLessonPart.count }.by(-1)
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:course_lesson) }
-    it { is_expected.to have_one(:next_lesson_part) }
+    it { is_expected.to have_one(:next_lesson_part).dependent(:destroy) }
     it { is_expected.to belong_to(:previous_lesson_part).optional }
   end
 

--- a/spec/models/course_lesson_part_spec.rb
+++ b/spec/models/course_lesson_part_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CourseLessonPart, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:course_lesson) }
-    it { is_expected.to have_one(:next_lesson_part).dependent(:destroy) }
+    it { is_expected.to have_one(:next_lesson_part).dependent(:nullify) }
     it { is_expected.to belong_to(:previous_lesson_part).optional }
   end
 

--- a/spec/policies/course_lesson_part_policy_spec.rb
+++ b/spec/policies/course_lesson_part_policy_spec.rb
@@ -12,17 +12,24 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:show_split) }
     it { is_expected.to permit_action(:split) }
-    it { is_expected.to forbid_action(:show_delete) }
-    it { is_expected.to forbid_action(:destroy) }
 
-    it "permits the show_delete action for admin when there is > 1 course lesson part" do
-      FactoryBot.create(:course_lesson_part, course_lesson: course_lesson_part.course_lesson)
-      is_expected.to permit_action(:show_delete)
+    describe "when there is > 1 course lesson part" do
+      before :each do
+        FactoryBot.create(:course_lesson_part, course_lesson: course_lesson_part.course_lesson)
+      end
+
+      it "permits the show_delete" do
+        is_expected.to permit_action(:show_delete)
+      end
+
+      it "permits the destroy action" do
+        is_expected.to permit_action(:destroy)
+      end
     end
 
-    it "permits the destroy action for admin when there is > 1 course lesson part" do
-      FactoryBot.create(:course_lesson_part, course_lesson: course_lesson_part.course_lesson)
-      is_expected.to permit_action(:destroy)
+    describe "when there is 1 course lesson part" do
+      it { is_expected.to forbid_action(:show_delete) }
+      it { is_expected.to forbid_action(:destroy) }
     end
   end
 

--- a/spec/policies/course_lesson_part_policy_spec.rb
+++ b/spec/policies/course_lesson_part_policy_spec.rb
@@ -12,8 +12,18 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:show_split) }
     it { is_expected.to permit_action(:split) }
-    it { is_expected.to permit_action(:show_delete) }
-    it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to forbid_action(:show_delete) }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "permits the show_delete action for admin when there is > 1 course lesson part" do
+      FactoryBot.create(:course_lesson_part, course_lesson: course_lesson_part.course_lesson)
+      is_expected.to permit_action(:show_delete)
+    end
+
+    it "permits the destroy action for admin when there is > 1 course lesson part" do
+      FactoryBot.create(:course_lesson_part, course_lesson: course_lesson_part.course_lesson)
+      is_expected.to permit_action(:destroy)
+    end
   end
 
   context "trying to edit as user" do

--- a/spec/policies/course_lesson_part_policy_spec.rb
+++ b/spec/policies/course_lesson_part_policy_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_action(:show_split) }
     it { is_expected.to permit_action(:split) }
+    it { is_expected.to permit_action(:show_delete) }
+    it { is_expected.to permit_action(:destroy) }
   end
 
   context "trying to edit as user" do
@@ -20,6 +22,8 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:show_split) }
     it { is_expected.to forbid_action(:split) }
+    it { is_expected.to forbid_action(:show_delete) }
+    it { is_expected.to forbid_action(:destroy) }
   end
 
   context "trying to edit as ECT" do
@@ -28,6 +32,8 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:show_split) }
     it { is_expected.to forbid_action(:split) }
+    it { is_expected.to forbid_action(:show_delete) }
+    it { is_expected.to forbid_action(:destroy) }
   end
 
   context "being a visitor" do
@@ -36,5 +42,7 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_action(:show_split) }
     it { is_expected.to forbid_action(:split) }
+    it { is_expected.to forbid_action(:show_delete) }
+    it { is_expected.to forbid_action(:destroy) }
   end
 end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
       end
     end
 
+    describe "DELETE /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id" do
+      it "deletes a course lesson part and redirects to a course lesson" do
+        post "#{course_lesson_part_url}/split", params: {
+          commit: "Save changes",
+          split_lesson_part_form: {
+            title: "Updated title one",
+            content: "Updated content",
+            new_title: "Title two",
+            new_content: "Content two",
+          },
+        }
+        delete course_lesson_part_url, params: { id: course_lesson.course_lesson_parts[1].id }
+
+        course_lesson_url = "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}/lessons/#{course_lesson.id}"
+
+        expect(CourseLessonPart.count).to eq(0)
+        expect(response).to redirect_to(course_lesson_url)
+      end
+    end
+
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
       it "renders the cip lesson part split page" do
         get "#{course_lesson_part_url}/split"
@@ -121,6 +141,13 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
         expect(course_lesson_part.next_lesson_part.next_lesson_part.content).to eq "Content two"
       end
     end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/show_delete" do
+      it "renders the cip lesson part show_delete page" do
+        get "#{course_lesson_part_url}/show_delete"
+        expect(response).to render_template(:show_delete)
+      end
+    end
   end
 
   describe "when a non-admin user is logged in" do
@@ -133,6 +160,12 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
       it "renders the cip lesson part page" do
         get course_lesson_part_url
         expect(response).to render_template(:show)
+      end
+    end
+
+    describe "DELETE /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id" do
+      it "raises an authorization error" do
+        expect { delete course_lesson_part_url }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
@@ -151,6 +184,12 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
       it "redirects to the sign in page" do
         expect { post "#{course_lesson_part_url}/split" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/show_delete" do
+      it "raises an authorization error" do
+        expect { get "#{course_lesson_part_url}/show_delete" }.to raise_error Pundit::NotAuthorizedError
       end
     end
   end
@@ -187,6 +226,20 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
       it "redirects to the sign in page" do
         post "#{course_lesson_part_url}/split"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/show_delete" do
+      it "redirects to the sign in page" do
+        get "#{course_lesson_part_url}/show_delete"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "DELETE /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id" do
+      it "redirects to the sign page" do
+        delete course_lesson_part_url
         expect(response).to redirect_to("/users/sign_in")
       end
     end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -170,19 +170,19 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     end
 
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/edit" do
-      it "redirects to the sign in page" do
+      it "raises an authorization error" do
         expect { get "#{course_lesson_part_url}/edit" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
-      it "redirects to the sign in page" do
+      it "raises an authorization error" do
         expect { get "#{course_lesson_part_url}/split" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     describe "POST /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
-      it "redirects to the sign in page" do
+      it "raises an authorization error" do
         expect { post "#{course_lesson_part_url}/split" }.to raise_error Pundit::NotAuthorizedError
       end
     end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
         expect(CourseLessonPart.count).to eq(1)
         expect(response).to redirect_to(course_lesson_url)
       end
+
+      it "raises an authorization error when there is 1 course lesson part" do
+        expect { delete course_lesson_part_url, params: { id: course_lesson.course_lesson_parts[0].id } }.to raise_error Pundit::NotAuthorizedError
+      end
     end
 
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/split" do
@@ -143,9 +147,14 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
     end
 
     describe "GET /core-induction-programme/years/:years_id/modules/:module_id/lessons/:lesson_id/parts/:part_id/show_delete" do
-      it "renders the cip lesson part show_delete page" do
+      it "renders the cip lesson part show_delete page when there is > 1 course lesson part" do
+        FactoryBot.create(:course_lesson_part, course_lesson: course_lesson)
         get "#{course_lesson_part_url}/show_delete"
         expect(response).to render_template(:show_delete)
+      end
+
+      it "raises an authorization error when there is 1 course lesson part" do
+        expect { get "#{course_lesson_part_url}/show_delete" }.to raise_error Pundit::NotAuthorizedError
       end
     end
   end

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
 
         course_lesson_url = "/core-induction-programme/years/#{course_year.id}/modules/#{course_module.id}/lessons/#{course_lesson.id}"
 
-        expect(CourseLessonPart.count).to eq(0)
+        expect(CourseLessonPart.count).to eq(1)
         expect(response).to redirect_to(course_lesson_url)
       end
     end


### PR DESCRIPTION
### Context
Admin can split out a lesson in to parts. We want them to also be able to delete If they can add, we want them to be able to delete parts

### Changes proposed in this pull request
- Updated routes 
- Functionality for admin to delete a course lesson part, providing additional step to confirm. 
- Update testing for requests to delete and view show_delete page 
- Updating CourseLessonPart model and tests
- amending it block statements for non-admin user requests, it didn't reflect what was being tested - probably my bad from a previous commit. 

### Guidance to review
I added dependant destroy to the model during testing as it was raising a violation of foreign key constraint on update or delete. Without this, the delete would still work in the app, but not in testing. Probably be helpful to discuss why this was happening. 

There's no check to see if there's only one lesson part and not then letting admin delete that lesson.  

### Testing
Updated request and model tests added. 