### PR TITLE
Add cookie page and banner

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CookiesController < ApplicationController
+  before_action :set_cookie_form, only: :show
+
+  def show; end
+
+  def update
+    analytics_consent = params[:cookies_form][:analytics_consent]
+    if %w[on off].include?(analytics_consent)
+      cookies[:cookie_consent_1] = { value: analytics_consent, expires: 1.year }
+    end
+
+    respond_to do |format|
+      format.html do
+        set_cookie_form
+        @consent_updated = true
+        render :show
+      end
+
+      format.json do
+        render json: {
+          status: "ok",
+          message: %(You've #{analytics_consent == 'on' ? 'accepted' : 'rejected'} analytics cookies.),
+        }
+      end
+    end
+  end
+
+private
+
+  def set_cookie_form
+    @cookies_form = CookiesForm.new(analytics_consent: cookies[:cookie_consent_1])
+  end
+end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -8,7 +8,7 @@ class CookiesController < ApplicationController
   def update
     analytics_consent = params[:cookies_form][:analytics_consent]
     if %w[on off].include?(analytics_consent)
-      cookies[:cookie_consent_1] = { value: analytics_consent, expires: 1.year }
+      cookies[:cookie_consent_1] = { value: analytics_consent, expires: 1.year.from_now }
     end
 
     respond_to do |format|

--- a/app/forms/cookies_form.rb
+++ b/app/forms/cookies_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CookiesForm
+  include ActiveModel::Model
+
+  attr_accessor :analytics_consent
+
+  def consent_options
+    [
+      OpenStruct.new(id: "on", name: "Yes"),
+      OpenStruct.new(id: "off", name: "No"),
+    ]
+  end
+end

--- a/app/views/cookies/_banner.html.erb
+++ b/app/views/cookies/_banner.html.erb
@@ -1,0 +1,48 @@
+<div class="govuk-cookie-banner js-cookie-banner" role="region" aria-label="Cookies on early careers framework">
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Early Careers Framework</h2>
+
+        <div class="govuk-cookie-banner__content">
+          <p>We use some essential cookies to make this service work.</p>
+          <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+        </div>
+      </div>
+    </div>
+
+    <%= form_with url: cookies_path, class: "js-cookie-form", method: :put do |f| %>
+      <div class="govuk-button-group">
+        <button type="submit" class="govuk-button" name="cookies_form[analytics_consent]" value="on">
+          Accept analytics cookies
+        </button>
+        <button type="submit" class="govuk-button" name="cookies_form[analytics_consent]" value="off">
+          Reject analytics cookies
+        </button>
+        <%= govuk_link_to "View cookies", cookies_path %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <div class="govuk-cookie-banner__content">
+          <p>
+            <span class="js-cookie-message">
+              You’ve set your cookie preferences.
+            </span>
+            You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-button-group">
+      <button class="govuk-button js-hide-cookie-banner">
+        Hide this message
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/cookies/_banner.html.erb
+++ b/app/views/cookies/_banner.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-cookie-banner js-cookie-banner" role="region" aria-label="Cookies on early careers framework">
-  <div class="govuk-cookie-banner__message govuk-width-container">
+  <div class="govuk-cookie-banner__message govuk-width-container js-cookie-banner__form">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Early Careers Framework</h2>
@@ -24,7 +24,7 @@
     <% end %>
   </div>
 
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert" hidden>
+  <div class="govuk-cookie-banner__message govuk-width-container js-cookie-banner__success" role="alert" hidden>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,0 +1,94 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @consent_updated %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">
+            You’ve set your cookie preferences.
+          </p>
+        </div>
+      </div>
+    <% end %>
+
+    <h1 class="govuk-heading-l">Cookies</h1>
+    <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+    <p>We use cookies to make the Early Career Framework (ECF) work and collect information about how you use our service.</p>
+
+    <h2 class="govuk-heading-m">Essential cookies</h2>
+    <p>Essential cookies keep your information secure while you use ECF. We do not need to ask permission to use them. </p>
+
+    <table class="govuk-table">
+      <caption class="govuk-visually-hidden">Essential cookies</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_govuk_rails_boilerplate_session</td>
+          <td class="govuk-table__cell" width="50%">Used to keep you signed in</td>
+          <td class="govuk-table__cell">2 weeks</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">cookie_consent_1</td>
+          <td class="govuk-table__cell" width="50%">Saves your cookie consent settings</td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-m">Analytics cookies (optional)</h2>
+    <p>With your permission, we use Google Analytics to collect data about how you use ECF. This information helps us to improve our service.</p>
+    <p>Google is not allowed to use or share our analytics data with anyone.</p>
+    <p>Google Analytics stores anonymised information about:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how you got to ECF</li>
+      <li>the pages you visit on ECF and how long you spend on them</li>
+      <li>any errors you see while using ECF</li>
+    </ul>
+
+    <table class="govuk-table">
+      <caption class="govuk-visually-hidden">Google Analytics cookies</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_ga</td>
+          <td class="govuk-table__cell" width="50%">Checks if you’ve visited ECF before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_gid</td>
+          <td class="govuk-table__cell" width="50%">Checks if you’ve visited ECF before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <%= form_for @cookies_form, url: cookies_path, method: :put do |f| %>
+      <%= f.govuk_collection_radio_buttons(
+        :analytics_consent,
+        @cookies_form.consent_options,
+        :id,
+        :name,
+        inline: true,
+        legend: { text: "Do you want to accept analytics cookies?" }) %>
+      <%= f.govuk_submit "Save cookie settings" %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,14 +15,10 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application', defer: true %>
+    <%= javascript_pack_tag 'application', defer: true unless params[:nojs] === "nojs" %>
   </head>
 
   <body class="govuk-template__body ">
-    <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <% unless cookies[:cookie_consent_1] || current_page?(cookies_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
+    <% unless cookies[:cookie_consent_1] || current_page?(cookies_path) %>
+      <%= render "cookies/banner" %>
+    <% end %>
+
     <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -4,5 +4,6 @@ require.context("govuk-frontend/govuk/assets");
 import "../styles/application.scss";
 import { initAll } from "govuk-frontend";
 import "./admin/supplier-users";
+import "./cookie-banner";
 
 initAll();

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,3 +1,7 @@
+document.body.className = document.body.className
+  ? `${document.body.className} js-enabled`
+  : "js-enabled";
+
 /* eslint-disable import/first */
 require.context("govuk-frontend/govuk/assets");
 

--- a/app/webpacker/packs/cookie-banner.js
+++ b/app/webpacker/packs/cookie-banner.js
@@ -1,0 +1,44 @@
+const cookieBannerEl = document.querySelector(".js-cookie-banner");
+
+if (cookieBannerEl) {
+  const cookieFormEl = document.querySelector(".js-cookie-form");
+
+  cookieFormEl.addEventListener("click", (e) => {
+    if (e.target.tagName !== "BUTTON") {
+      return;
+    }
+
+    fetch(cookieFormEl.action, {
+      method: "PUT",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        cookies_form: { analytics_consent: e.target.value },
+      }),
+    })
+      .then((res) => res.json())
+      .then(({ message }) => {
+        const messageEl = cookieBannerEl.querySelector(".js-cookie-message");
+        messageEl.textContent = message;
+
+        Array.from(cookieBannerEl.children).forEach((childEl) => {
+          if (childEl.hasAttribute("hidden")) {
+            childEl.removeAttribute("hidden");
+          } else {
+            childEl.setAttribute("hidden", "");
+          }
+        });
+      });
+
+    e.preventDefault();
+  });
+
+  const hideBannerEl = document.querySelector(".js-hide-cookie-banner");
+  hideBannerEl.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    cookieBannerEl.setAttribute("hidden", "");
+  });
+}

--- a/app/webpacker/packs/cookie-banner.js
+++ b/app/webpacker/packs/cookie-banner.js
@@ -23,13 +23,12 @@ if (cookieBannerEl) {
         const messageEl = cookieBannerEl.querySelector(".js-cookie-message");
         messageEl.textContent = message;
 
-        Array.from(cookieBannerEl.children).forEach((childEl) => {
-          if (childEl.hasAttribute("hidden")) {
-            childEl.removeAttribute("hidden");
-          } else {
-            childEl.setAttribute("hidden", "");
-          }
-        });
+        cookieBannerEl
+          .querySelector(".js-cookie-banner__form")
+          .setAttribute("hidden", "");
+        cookieBannerEl
+          .querySelector(".js-cookie-banner__success")
+          .removeAttribute("hidden");
       });
 
     e.preventDefault();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get "check" => "application#check"
 
+  resource :cookies, controller: :cookies, only: %i[show update]
   resource :dashboard, controller: :dashboard, only: :show
 
   get "/403", to: "errors#forbidden", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
   get "check" => "application#check"
 
-  resource :cookies, controller: :cookies, only: %i[show update]
+  resource :cookies, only: %i[show update]
   resource :dashboard, controller: :dashboard, only: :show
 
   get "/403", to: "errors#forbidden", via: :all

--- a/spec/cypress/integration/cookies.js
+++ b/spec/cypress/integration/cookies.js
@@ -28,8 +28,8 @@ describe("Cookie consent", () => {
     );
   });
 
-  it.skip("should be settable through a cookie banner without js", () => {
-    cy.visit("/");
+  it("should be settable through a cookie banner without js", () => {
+    cy.visit("/?nojs=nojs");
 
     cy.get(".js-cookie-form").contains("Accept").click();
 

--- a/spec/cypress/integration/cookies.js
+++ b/spec/cypress/integration/cookies.js
@@ -1,0 +1,78 @@
+describe("Cookie consent", () => {
+  it("should be settable on a cookies page", () => {
+    cy.visit("/cookies");
+
+    cy.get('[name="cookies_form[analytics_consent]"]')
+      .should("not.be.checked")
+      .get('[value="on"]')
+      .click();
+
+    cy.get('[name="commit"]').click();
+
+    // @todo replace with visual test
+    cy.contains("You’ve set your cookie preferences.");
+
+    cy.get('[name="cookies_form[analytics_consent]"]')
+      .as("cookieRadios")
+      .get('[value="on"]')
+      .should("be.checked");
+
+    cy.get("@cookieRadios").get('[value="off"]').click();
+
+    cy.get('[name="commit"]').click();
+
+    cy.contains("You’ve set your cookie preferences.");
+
+    cy.get('[name="cookies_form[analytics_consent]"][value="off"]').should(
+      "be.checked"
+    );
+  });
+
+  it.skip("should be settable through a cookie banner without js", () => {
+    cy.visit("/");
+
+    cy.get(".js-cookie-form").contains("Accept").click();
+
+    cy.contains("You’ve set your cookie preferences.");
+
+    cy.get('[name="cookies_form[analytics_consent]"][value="on"]').should(
+      "be.checked"
+    );
+  });
+
+  it("should be settable through a cookie banner with js", () => {
+    cy.visit("/");
+
+    cy.get(".js-cookie-form").contains("Accept").click();
+
+    cy.contains("You've accepted analytics cookies.");
+
+    cy.get(".js-cookie-banner").contains("Hide this message").click();
+
+    cy.get(".js-cookie-banner").should("not.be.visible");
+
+    cy.visit("/cookies");
+
+    cy.get('[name="cookies_form[analytics_consent]"][value="on"]').should(
+      "be.checked"
+    );
+
+    cy.clearCookies();
+
+    cy.visit("/");
+
+    cy.get(".js-cookie-form").contains("Reject").click();
+
+    cy.contains("You've rejected analytics cookies.");
+
+    cy.get(".js-cookie-banner").contains("Hide this message").click();
+
+    cy.get(".js-cookie-banner").should("not.be.visible");
+
+    cy.visit("/cookies");
+
+    cy.get('[name="cookies_form[analytics_consent]"][value="off"]').should(
+      "be.checked"
+    );
+  });
+});

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Cookies API", type: :request do
   describe "PUT /cookies" do
     it "handles analytics cookie acceptance" do
       headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
-      put "/cookies", params: '{"cookies_form":{"analytics_consent":"on"}}', headers: headers
+      put "/cookies", params: { "cookies_form": { "analytics_consent": "on" } }.to_json, headers: headers
 
       expected = { status: "ok", message: "You've accepted analytics cookies." }.to_json
       expect(response.content_type).to include("application/json")
@@ -16,7 +16,7 @@ RSpec.describe "Cookies API", type: :request do
 
     it "handles analytics cookie rejection" do
       headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
-      put "/cookies", params: '{"cookies_form":{"analytics_consent":"off"}}', headers: headers
+      put "/cookies", params: { "cookies_form": { "analytics_consent": "off" } }.to_json, headers: headers
 
       expected = { status: "ok", message: "You've rejected analytics cookies." }.to_json
       expect(response.content_type).to include("application/json")

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cookies API", type: :request do
+  describe "PUT /cookies" do
+    it "handles analytics cookie acceptance" do
+      headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
+      put "/cookies", params: '{"cookies_form":{"analytics_consent":"on"}}', headers: headers
+
+      expected = { status: "ok", message: "You've accepted analytics cookies." }.to_json
+      expect(response.content_type).to include("application/json")
+      expect(response.body).to eq(expected)
+      expect(response.cookies["cookie_consent_1"]).to eq("on")
+    end
+
+    it "handles analytics cookie rejection" do
+      headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
+      put "/cookies", params: '{"cookies_form":{"analytics_consent":"off"}}', headers: headers
+
+      expected = { status: "ok", message: "You've rejected analytics cookies." }.to_json
+      expect(response.content_type).to include("application/json")
+      expect(response.body).to eq(expected)
+      expect(response.cookies["cookie_consent_1"]).to eq("off")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Nicked the copy from https://www.notifications.service.gov.uk/cookies - I imagine it'll need changing at some point in the future!

### Changes proposed in this pull request

- Add a cookie page explaining what cookies we use. We don't use GA yet but apparently we're going to.
- Add a cookie banner to every page but the cookie page when consent hasn't been given yet. When JS is available, doesn't require a page reload to use.

### Guidance to review

I'll be send the same code to the other repo so would appreciate some team one reviews here too.

### Testing

I don't have access to IE to test this, but it could use some testing.