### PR TITLE
Create additional years for a cip

### DIFF
--- a/app/controllers/core_induction_programmes/years_controller.rb
+++ b/app/controllers/core_induction_programmes/years_controller.rb
@@ -10,16 +10,18 @@ class CoreInductionProgrammes::YearsController < ApplicationController
   before_action :load_course_year, except: %i[new create]
 
   def new
-    authorize User
+    authorize CourseYear
     @core_induction_programmes = CoreInductionProgramme.all
     @course_year = CourseYear.new
   end
 
   def create
-    @course_year = CourseYear.new(params.require(:course_year).permit(
-      :title, :content
-    ).merge(is_year_one: false, core_induction_programme: find_core_induction_programme))
-    authorize @course_year
+    authorize CourseYear
+    @course_year = CourseYear.new(
+      course_year_params.merge(
+        is_year_one: false, core_induction_programme: find_core_induction_programme,
+      ),
+    )
 
     if @course_year.valid?
       @course_year.save!
@@ -52,10 +54,12 @@ private
   end
 
   def course_year_params
-    params.permit(:title, :content)
+    return {} unless params.key? :course_year
+
+    params.require(:course_year).permit(:title, :content)
   end
 
   def find_core_induction_programme
-    CoreInductionProgramme.find_by(id: params[:course_year][:core_induction_programme_id])
+    CoreInductionProgramme.find_by(id: params[:course_year][:core_induction_programme])
   end
 end

--- a/app/controllers/core_induction_programmes/years_controller.rb
+++ b/app/controllers/core_induction_programmes/years_controller.rb
@@ -7,7 +7,28 @@ class CoreInductionProgrammes::YearsController < ApplicationController
 
   after_action :verify_authorized
   before_action :authenticate_user!
-  before_action :load_course_year
+  before_action :load_course_year, except: %i[new create]
+
+  def new
+    authorize User
+    @core_induction_programmes = CoreInductionProgramme.all
+    @course_year = CourseYear.new
+  end
+
+  def create
+    @course_year = CourseYear.new(params.require(:course_year).permit(
+      :title, :content
+    ).merge(is_year_one: false, core_induction_programme: find_core_induction_programme))
+    authorize @course_year
+
+    if @course_year.valid?
+      @course_year.save!
+      redirect_to cip_index_path
+    else
+      @core_induction_programmes = CoreInductionProgramme.all
+      render action: "new"
+    end
+  end
 
   def edit; end
 
@@ -31,6 +52,10 @@ private
   end
 
   def course_year_params
-    params.permit(:content, :title)
+    params.permit(:title, :content)
+  end
+
+  def find_core_induction_programme
+    CoreInductionProgramme.find_by(id: params[:course_year][:core_induction_programme_id])
   end
 end

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -4,11 +4,12 @@ class CourseYear < ApplicationRecord
   include CourseLessonProgressHelper
   include OrderHelper
 
-  belongs_to :core_induction_programme, optional: true
+  belongs_to :core_induction_programme
   has_many :course_modules, dependent: :delete_all
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
   validates :content, presence: { message: "Enter content" }, length: { maximum: 100_000 }
+  validates :core_induction_programme_id, presence: { message: "Select a provider" }
 
   def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -4,12 +4,12 @@ class CourseYear < ApplicationRecord
   include CourseLessonProgressHelper
   include OrderHelper
 
+  validates :core_induction_programme, presence: { message: "Select a provider" }
   belongs_to :core_induction_programme
   has_many :course_modules, dependent: :delete_all
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
   validates :content, presence: { message: "Enter content" }, length: { maximum: 100_000 }
-  validates :core_induction_programme_id, presence: { message: "Select a provider" }
 
   def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html

--- a/app/policies/course_year_policy.rb
+++ b/app/policies/course_year_policy.rb
@@ -6,6 +6,10 @@ class CourseYearPolicy < ApplicationPolicy
     @record = record
   end
 
+  def new?
+    admin_only
+  end
+
   def show?
     true
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class UserPolicy < ApplicationPolicy
+  def new?
+    admin_only
+  end
+
   def show?
     admin_only
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class UserPolicy < ApplicationPolicy
-  def new?
-    admin_only
-  end
-
   def show?
     admin_only
   end

--- a/app/views/core_induction_programmes/index.html.erb
+++ b/app/views/core_induction_programmes/index.html.erb
@@ -2,6 +2,7 @@
   <div class="govuk-grid-column-full">
     <% if @current_user&.admin? %>
       <%= govuk_link_to "Download export", download_export_path, button: true%>
+      <%= govuk_link_to "Create CIP Year", new_year_path, button: true %>
     <% end %>
     <h1 class="govuk-heading-xl">What is the early career framework?</h1>
     <p>The early career framework (ECF) was designed to make sure early career teachers focus on learning the things that make the most difference in the classroom and their professional practice.</p>

--- a/app/views/core_induction_programmes/show.html.erb
+++ b/app/views/core_induction_programmes/show.html.erb
@@ -4,12 +4,12 @@
     <h1 class="govuk-heading-xl">The Early Career Framework study material</h1>
 
     <% if @core_induction_programme.course_years.any? %>
-      <% @core_induction_programme.course_years.each do |course_year| %>
+      <% @core_induction_programme.course_years.each_with_index do |course_year, index| %>
+        <h2 class="govuk-heading-xl govuk-!-margin-top-8"><%= "Year #{index + 1}" %></h2>
         <h2 class="govuk-heading-l"><%= course_year.title %></h2>
         <% if policy(course_year).edit? %>
           <%= govuk_link_to "Edit year content", edit_year_url(course_year), button: true %>
         <% end %>
-
         <div class="gem-c-govspeak govuk-govspeak ">
           <%= course_year.content_to_html.html_safe %>
         </div>

--- a/app/views/core_induction_programmes/years/edit.html.erb
+++ b/app/views/core_induction_programmes/years/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
-    <%= form_with url: year_path, method: :put do |f| %>
+    <%= form_with model: @course_year, url: year_path, method: :put do |f| %>
       <%= f.govuk_text_field :title, label: { text: "Year title" }, value: @course_year.title %>
       <%= f.govuk_text_area :content, label: { text: "Markdown string for course year content" }, rows: 10, value: @course_year.content %>
       <%= f.govuk_submit "See preview" %>

--- a/app/views/core_induction_programmes/years/new.html.erb
+++ b/app/views/core_induction_programmes/years/new.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Create an additional course year</h1>
+    <%= form_with model: @course_year, url: years_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+            :core_induction_programme_id, @core_induction_programmes, :id, :name,
+          legend: { text: "Which provider would you like to create an additional year for?" , class: "govuk-heading-m" }
+          ) %>
+      <%= f.govuk_text_field :title, label: { text: 'Course year title' } %>
+      <%= f.govuk_text_area :content,
+                            label: { text: 'Course year content' },
+                            hint: { text: 'This content will be included at the top of the course year' },
+                            rows: 9 %>
+      <%= f.govuk_submit "Create" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/core_induction_programmes/years/new.html.erb
+++ b/app/views/core_induction_programmes/years/new.html.erb
@@ -4,7 +4,7 @@
     <%= form_with model: @course_year, url: years_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
-            :core_induction_programme_id, @core_induction_programmes, :id, :name,
+            :core_induction_programme, @core_induction_programmes, :id, :name,
           legend: { text: "Which provider would you like to create an additional year for?" , class: "govuk-heading-m" }
           ) %>
       <%= f.govuk_text_field :title, label: { text: 'Course year title' } %>

--- a/app/views/core_induction_programmes/years/new.html.erb
+++ b/app/views/core_induction_programmes/years/new.html.erb
@@ -4,14 +4,19 @@
     <%= form_with model: @course_year, url: years_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
-            :core_induction_programme, @core_induction_programmes, :id, :name,
-          legend: { text: "Which provider would you like to create an additional year for?" , class: "govuk-heading-m" }
+            :core_induction_programme,
+            @core_induction_programmes,
+            :id,
+            :name,
+            legend: { text: "Which provider would you like to create an additional year for?" , class: "govuk-heading-m" }
           ) %>
       <%= f.govuk_text_field :title, label: { text: 'Course year title' } %>
-      <%= f.govuk_text_area :content,
-                            label: { text: 'Course year content' },
-                            hint: { text: 'This content will be included at the top of the course year' },
-                            rows: 9 %>
+      <%= f.govuk_text_area(
+            :content,
+            label: { text: 'Course year content' },
+            hint: { text: 'This content will be included at the top of the course year' },
+            rows: 10
+          ) %>
       <%= f.govuk_submit "Create" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   resources :core_induction_programmes, path: "core-induction-programmes", only: %i[show index], as: "cip"
   get "download-export", to: "core_induction_programmes#download_export", as: :download_export
 
-  resources :years, controller: "core_induction_programmes/years", only: %i[edit update] do
+  resources :years, controller: "core_induction_programmes/years", only: %i[new create edit update] do
     resources :modules, controller: "core_induction_programmes/modules", only: %i[show edit update] do
       resources :lessons, controller: "core_induction_programmes/lessons", only: %i[show edit update] do
         resources :parts, controller: "core_induction_programmes/lesson_parts", only: %i[show edit update destroy] do

--- a/db/migrate/20210318163012_change_core_induction_programme_id_null_on_course_years.rb
+++ b/db/migrate/20210318163012_change_core_induction_programme_id_null_on_course_years.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeCoreInductionProgrammeIdNullOnCourseYears < ActiveRecord::Migration[6.1]
+  def self.up
+    change_column_null :course_years, :core_induction_programme_id, false
+  end
+
+  def self.down
+    change_column_null :course_years, :core_induction_programme_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_114107) do
+ActiveRecord::Schema.define(version: 2021_03_18_163012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 2021_03_10_114107) do
     t.string "title", null: false
     t.text "content", null: false
     t.integer "version", default: 1, null: false
-    t.uuid "core_induction_programme_id"
+    t.uuid "core_induction_programme_id", null: false
     t.index ["core_induction_programme_id"], name: "index_course_years_on_core_induction_programme_id"
   end
 

--- a/spec/cypress/integration/cip-stories-admin.js
+++ b/spec/cypress/integration/cip-stories-admin.js
@@ -18,7 +18,7 @@ describe("Admin user interaction with Core Induction Programme", () => {
       cy.get("a.govuk-button").contains("Edit year content").click();
 
       cy.get("h1").should("contain", "Content change preview");
-      cy.get("input[name='title']").type("New title");
+      cy.get("input[name='course_year[title]']").type("New title");
       cy.contains("See preview").click();
 
       cy.get("h1").should("contain", "Content change preview");
@@ -27,7 +27,7 @@ describe("Admin user interaction with Core Induction Programme", () => {
       );
 
       cy.get("a.govuk-button").contains("Edit year content").click();
-      cy.get("input[name='title']").type("New title");
+      cy.get("input[name='course_year[title]']").type("New title");
       cy.contains("Save changes").click();
 
       cy.get("h2").should("contain", "New title");

--- a/spec/models/core_induction_programme.rb
+++ b/spec/models/core_induction_programme.rb
@@ -15,7 +15,7 @@ RSpec.describe CoreInductionProgramme, type: :model do
       course_year_one = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
       course_year_two = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
 
-      expect(course_year_one[:core_induction_programme]).to eql(course_year_two[:core_induction_programme])
+      expect(course_year_one.core_induction_programme).to eql(course_year_two.core_induction_programme)
       expect(core_induction_programme.course_years.count).to eq(2)
     end
   end

--- a/spec/models/core_induction_programme.rb
+++ b/spec/models/core_induction_programme.rb
@@ -8,4 +8,15 @@ RSpec.describe CoreInductionProgramme, type: :model do
     it { is_expected.to have_many(:early_career_teacher_profiles) }
     it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
   end
+
+  describe "course_years" do
+    it "returns multiple course years for a single core_induction_programme" do
+      core_induction_programme = FactoryBot.create(:core_induction_programme)
+      course_year_one = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
+      course_year_two = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
+
+      expect(course_year_one[:core_induction_programme]).to eql(course_year_two[:core_induction_programme])
+      expect(core_induction_programme.course_years.count).to eq(2)
+    end
+  end
 end

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CourseYear, type: :model do
     it { is_expected.to validate_length_of(:title).is_at_most(255) }
     it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
     it { is_expected.to validate_length_of(:content).is_at_most(100_000) }
-    it { is_expected.to validate_presence_of(:core_induction_programme_id).with_message("Select a provider") }
+    it { is_expected.to validate_presence_of(:core_induction_programme).with_message("Select a provider") }
   end
 
   describe "course_modules" do

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe CourseYear, type: :model do
         title: "Test Course year",
         content: "No content",
         is_year_one: false,
+        core_induction_programme: FactoryBot.create(:core_induction_programme),
       )
     }.to change { CourseYear.count }.by(1)
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:core_induction_programme).optional }
+    it { is_expected.to belong_to(:core_induction_programme) }
     it { is_expected.to have_many(:course_modules) }
   end
 
@@ -24,6 +25,7 @@ RSpec.describe CourseYear, type: :model do
     it { is_expected.to validate_length_of(:title).is_at_most(255) }
     it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
     it { is_expected.to validate_length_of(:content).is_at_most(100_000) }
+    it { is_expected.to validate_presence_of(:core_induction_programme_id).with_message("Select a provider") }
   end
 
   describe "course_modules" do

--- a/spec/policies/course_year_policy_spec.rb
+++ b/spec/policies/course_year_policy_spec.rb
@@ -11,15 +11,18 @@ RSpec.describe CourseYearPolicy, type: :policy do
 
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_new_and_create_actions }
   end
   context "trying to edit as user" do
     let(:user) { create(:user) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
   end
   context "being a visitor" do
     let(:user) { nil }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
   end
 end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -122,7 +122,9 @@ end
 private
 
 def create_course_year
-  post "/years", params: { course_year: { title: "Additional year title",
-                                          content: "Additional year content",
-                                          core_induction_programme: course_year.core_induction_programme[:id] } }
+  post "/years", params: { course_year: {
+    title: "Additional year title",
+    content: "Additional year content",
+    core_induction_programme: course_year.core_induction_programme[:id],
+  } }
 end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -12,6 +12,26 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       sign_in admin_user
     end
 
+    describe "GET /years/new" do
+      it "renders the cip new years page" do
+        get "/years/new"
+        expect(response).to render_template(:new)
+      end
+    end
+
+    describe "POST /years" do
+      it "creates a new year, redirecting to the CIP homepage" do
+        expect(create_course_year).to redirect_to("/core-induction-programmes")
+      end
+
+      it "creates a new year that renders on the course year show page" do
+        create_course_year
+        get cip_url(course_year.core_induction_programme[:id])
+        expect(response.body).to include("Additional year title")
+        expect(response.body).to include("Additional year content")
+      end
+    end
+
     describe "GET /years/years_id/edit" do
       it "render the cip years edit page" do
         get "#{course_year_url}/edit"
@@ -50,6 +70,18 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       sign_in user
     end
 
+    describe "GET /years/new" do
+      it "raises an error when trying to create a new year page" do
+        expect { get "/years/new" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "POST /years" do
+      it "raises an error when trying to post a new year" do
+        expect { create_course_year }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
     describe "GET /years/years_id/edit" do
       it "raises an error when trying to access edit page" do
         expect { get "#{course_year_url}/edit" }.to raise_error Pundit::NotAuthorizedError
@@ -58,6 +90,19 @@ RSpec.describe "Core Induction Programme Year", type: :request do
   end
 
   describe "when a non-user is accessing the year page" do
+    describe "GET /years/new" do
+      it "raises an error when trying to create a new year page" do
+        get "/years/new"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "POST /years" do
+      it "raises an error when trying to post a new year" do
+        expect(create_course_year).to redirect_to("/users/sign_in")
+      end
+    end
+
     describe "GET /years/years_id/edit" do
       it "redirects to the sign in page" do
         get "#{course_year_url}/edit"
@@ -72,4 +117,12 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
   end
+end
+
+private
+
+def create_course_year
+  post "/years", params: { course_year: { title: "Additional year title",
+                                          content: "Additional year content",
+                                          core_induction_programme_id: course_year.core_induction_programme[:id] } }
 end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe "Core Induction Programme Year", type: :request do
 
     describe "GET /years/years_id/edit" do
       it "render the cip years edit page" do
-        get "#{course_year_url}/edit"
+        get "#{course_year_url}/edit", params: { course_year: { id: course_year.id } }
         expect(response).to render_template(:edit)
       end
     end
 
     describe "PUT /years/years_id" do
       it "renders a preview of changes to a year" do
-        put course_year_url, params: { commit: "See preview", content: "Extra content" }
+        put course_year_url, params: { commit: "See preview", course_year: { content: "Extra content" } }
         expect(response).to render_template(:edit)
         expect(response.body).to include("Extra content")
         course_year.reload
@@ -49,14 +49,14 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
 
       it "redirects to the year page and updates content when saving changes" do
-        put course_year_url, params: { commit: "Save changes", content: "Adding new content" }
+        put course_year_url, params: { commit: "Save changes", course_year: { content: "Adding new content" } }
         expect(response).to redirect_to(cip_url(course_year.core_induction_programme))
         get cip_url(course_year.core_induction_programme)
         expect(response.body).to include("Adding new content")
       end
 
       it "redirects to the year page when saving title" do
-        put course_year_url, params: { commit: "Save changes", title: "New title" }
+        put course_year_url, params: { commit: "Save changes", course_year: { title: "New title" } }
         expect(response).to redirect_to(cip_url(course_year.core_induction_programme))
         get cip_url(course_year.core_induction_programme)
         expect(response.body).to include("New title")
@@ -124,5 +124,5 @@ private
 def create_course_year
   post "/years", params: { course_year: { title: "Additional year title",
                                           content: "Additional year content",
-                                          core_induction_programme_id: course_year.core_induction_programme[:id] } }
+                                          core_induction_programme: course_year.core_induction_programme[:id] } }
 end


### PR DESCRIPTION
### Context
We want admin to be able to create additional years, Year 1, Year 2 etc.

### Changes proposed in this pull request
- create a migration that sets the core_induction_programme_id to null: false(We don't want to have course_years that aren't assigned to a cip). 
- updated routes and policies to allow admin to create a new course year, whilst restricting non-admin users. 
- updated views, including adding new.html.erb for creating a course year. 
- updated specs for the above

### Guidance to review
I had a look at various ways of doing the migration to add null: false. 2-3 different ways worked, change_column_null, add_column/remove_column and the up/down set in the migration. I went with this as my first attempt with change_change column didn't allow a rollback. Also adding then removing the same column just with null: false seemed unnecessary. The problem i've come across is that when you try to create a new cip year is that i can't get rid of the "must exist" warning. I've tried various ways to just have the select provider but can't quite get it. 

Note - This was fixed by simply moving the validates... presence { message: "Select a provider"} above the belongs_to. Otherwise the first error message on the belongs_to takes precedent over the validation message. This message is just Rails' default 'must enter'

### Testing
Various tests have been added but there could be some additional ones required. 