### PR TITLE
Allow admin to set the module a lesson is assigned to

### DIFF
--- a/app/controllers/core_induction_programmes/lessons_controller.rb
+++ b/app/controllers/core_induction_programmes/lessons_controller.rb
@@ -34,10 +34,11 @@ private
 
   def load_course_lesson
     @course_lesson = CourseLesson.find(params[:id])
+    @course_modules = CourseModule.where(course_year_id: @course_lesson.course_module[:course_year_id])
     authorize @course_lesson
   end
 
   def course_lesson_params
-    params.require(:course_lesson).permit(:title, :completion_time_in_minutes)
+    params.require(:course_lesson).permit(:title, :completion_time_in_minutes, :course_module_id)
   end
 end

--- a/app/views/core_induction_programmes/lessons/edit.html.erb
+++ b/app/views/core_induction_programmes/lessons/edit.html.erb
@@ -5,6 +5,13 @@
     <%= form_with model: @course_lesson, url: year_module_lesson_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :title, label: { text: "Lesson title" }, value: @course_lesson.title %>
+      <%= f.govuk_collection_select(
+            :course_module_id,
+            @course_modules,
+            :id,
+            :term_and_title,
+            label: { text: "Which module would you like the lesson to be assigned to?" },
+            ) %>
       <%= f.govuk_number_field(
             :completion_time_in_minutes,
             label: { text: "Time in minutes"},

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
         expect(response).to render_template(:edit)
         expect(response.body).to include("Enter a number greater than 0")
       end
+
+      it "allows a course lesson to be reassigned to a different course module" do
+        second_course_module = FactoryBot.create(:course_module)
+        put course_lesson_url, params: { course_lesson: { commit: "Save changes", course_module_id: second_course_module[:id] } }
+        course_lesson.reload
+        expect(course_lesson[:course_module_id]).to eq(second_course_module[:id])
+      end
     end
   end
 


### PR DESCRIPTION
### Context
We want admin to be able to move lessons between modules. This gives a basic implementation of being able to do that.

### Changes proposed in this pull request
Adding a collection select, listing modules that a lesson can be assigned to. 
Assigning that lesson to the selected module. 

### Guidance to review
There's no changes made in this PR to the previous lesson relationship for a course lesson. 

### Testing
Additional request test to check a course lesson has been assigned to the selected module. 
