### PR TITLE
Restrict cip access for ect

### DIFF
--- a/app/controllers/core_induction_programmes_controller.rb
+++ b/app/controllers/core_induction_programmes_controller.rb
@@ -10,6 +10,7 @@ class CoreInductionProgrammesController < ApplicationController
 
   def show
     @core_induction_programme = CoreInductionProgramme.find(params[:id])
+    authorize @core_induction_programme
   end
 
   def download_export
@@ -24,5 +25,5 @@ class CoreInductionProgrammesController < ApplicationController
     else
       redirect_to cip_index_path
     end
-  end
+end
 end

--- a/app/controllers/core_induction_programmes_controller.rb
+++ b/app/controllers/core_induction_programmes_controller.rb
@@ -5,6 +5,7 @@ class CoreInductionProgrammesController < ApplicationController
   include CipBreadcrumbHelper
 
   def index
+    authorize CoreInductionProgramme
     @core_induction_programmes = CoreInductionProgramme.all
   end
 
@@ -25,5 +26,5 @@ class CoreInductionProgrammesController < ApplicationController
     else
       redirect_to cip_index_path
     end
-end
+  end
 end

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class StartController < ApplicationController
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,10 +6,10 @@ class Users::SessionsController < Devise::SessionsController
 
   TEST_USERS = %w[
     admin@example.com
-    early-career-teacher-1@example.com
-    early-career-teacher-2@example.com
-    early-career-teacher-3@example.com
-    early-career-teacher-4@example.com
+    ambition-institute-early-career-teacher@example.com
+    education-development-trust-early-career-teacher@example.com
+    teach-first-early-career-teacher@example.com
+    ucl-early-career-teacher@example.com
     mentor@example.com
   ].freeze
 
@@ -61,9 +61,5 @@ private
     user = User.find_by_email(email)
     sign_in(user, scope: :user)
     redirect_to dashboard_url
-  end
-
-  def after_sign_out_path_for(_resource_or_scope)
-    new_user_session_url
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,7 +4,14 @@ class Users::SessionsController < Devise::SessionsController
   class EmailNotFoundError < StandardError; end
   class LoginIncompleteError < StandardError; end
 
-  TEST_USERS = %w[admin@example.com early-career-teacher@example.com mentor@example.com].freeze
+  TEST_USERS = %w[
+    admin@example.com
+    early-career-teacher-1@example.com
+    early-career-teacher-2@example.com
+    early-career-teacher-3@example.com
+    early-career-teacher-4@example.com
+    mentor@example.com
+  ].freeze
 
   before_action :mock_login, only: :create, unless: -> { Rails.env.production? }
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
@@ -54,5 +61,9 @@ private
     user = User.find_by_email(email)
     sign_in(user, scope: :user)
     redirect_to dashboard_url
+  end
+
+  def after_sign_out_path_for(_resource_or_scope)
+    new_user_session_url
   end
 end

--- a/app/policies/core_induction_programme_policy.rb
+++ b/app/policies/core_induction_programme_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CoreInductionProgrammePolicy < ApplicationPolicy
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def show?
+    ect_has_access_to_cip?
+  end
+end
+
+private
+
+def ect_has_access_to_cip?
+  if @user.core_induction_programme == @record
+    true
+  else
+    admin_only
+  end
+end

--- a/app/policies/core_induction_programme_policy.rb
+++ b/app/policies/core_induction_programme_policy.rb
@@ -6,6 +6,10 @@ class CoreInductionProgrammePolicy < ApplicationPolicy
     @record = record
   end
 
+  def index?
+    admin_only
+  end
+
   def show?
     ect_has_access_to_cip?
   end
@@ -14,7 +18,7 @@ end
 private
 
 def ect_has_access_to_cip?
-  if @user.core_induction_programme == @record
+  if @user&.core_induction_programme == @record
     true
   else
     admin_only

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Early Career Framework</h1>
+    <h2>Engage and Learn Start Page</h2>
+    <%= govuk_link_to "Start", new_user_session_path, button: true %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,5 +50,5 @@ Rails.application.routes.draw do
       get "show_delete", to: "lesson_parts#show_delete"
     end
   end
-  root to: "core_induction_programmes#index"
+  root to: "start#index"
 end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -31,9 +31,11 @@ unless Rails.env.production?
   end
 
   if EarlyCareerTeacherProfile.none?
-    CoreInductionProgramme.all.each_with_index do |cip, index|
-      user = User.find_or_create_by!(email: "early-career-teacher-#{index + 1}@example.com") do |u|
-        u.full_name = "ECT User #{index + 1}"
+    CoreInductionProgramme.all.each do |cip|
+      cip_name_for_email = cip.name.gsub(/\s+/, "-").downcase
+
+      user = User.find_or_create_by!(email: "#{cip_name_for_email}-early-career-teacher@example.com") do |u|
+        u.full_name = "#{cip.name} ECT User"
         u.confirmed_at = Time.zone.now.utc
       end
       EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: cip, mentor_profile: MentorProfile.first)

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -31,10 +31,12 @@ unless Rails.env.production?
   end
 
   if EarlyCareerTeacherProfile.none?
-    user = User.find_or_create_by!(email: "early-career-teacher@example.com") do |u|
-      u.full_name = "ECT User"
-      u.confirmed_at = Time.zone.now.utc
+    CoreInductionProgramme.all.each_with_index do |cip, index|
+      user = User.find_or_create_by!(email: "early-career-teacher-#{index + 1}@example.com") do |u|
+        u.full_name = "ECT User #{index + 1}"
+        u.confirmed_at = Time.zone.now.utc
+      end
+      EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: cip, mentor_profile: MentorProfile.first)
     end
-    EarlyCareerTeacherProfile.create!(user: user, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first, mentor_profile: MentorProfile.first)
   end
 end

--- a/spec/cypress/integration/aaa-meta.js
+++ b/spec/cypress/integration/aaa-meta.js
@@ -44,6 +44,8 @@ describe("Meta test helper tests", () => {
       ["create", "core_induction_programme"],
     ]);
 
+    cy.login("admin");
+
     cy.visit("/core-induction-programmes");
 
     cy.get('.govuk-link:contains("Test Core induction programme")').should(
@@ -52,8 +54,8 @@ describe("Meta test helper tests", () => {
     );
 
     cy.app("clean");
-
-    cy.reload();
+    cy.login("admin");
+    cy.visit("/core-induction-programmes");
 
     cy.get('.govuk-link:contains("Test Core induction programme")').should(
       "have.length",

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -46,7 +46,7 @@ describe("Accessibility", () => {
   it("CIP should be accessible", () => {
     cy.appFactories([["create", "core_induction_programme"]]);
 
-    cy.login("early_career_teacher");
+    cy.login("admin");
 
     cy.visit("/core-induction-programmes");
     cy.checkA11y();

--- a/spec/cypress/integration/cip-stories-early-career-teacher.js
+++ b/spec/cypress/integration/cip-stories-early-career-teacher.js
@@ -3,22 +3,23 @@ describe("ECT user interaction with Core Induction Programme", () => {
     cy.login("early_career_teacher");
   });
 
-  it("should not show a download export button", () => {
-    cy.visit("/core-induction-programmes");
-    cy.contains("a.govuk-button", "Download export").should("not.exist");
-  });
-
   it("should not allow to edit year title", () => {
     cy.appFactories([["create", "course_year"]]).as("courseYear");
 
     cy.get("@courseYear").then(([year]) => {
-      cy.appFactories([
-        ["create", "core_induction_programme", { course_year_one_id: year.id }],
-      ]).as("coreInductionProgramme");
-
-      cy.get("@coreInductionProgramme").then(([coreInductionProgramme]) => {
-        cy.visit(`/core-induction-programmes/${coreInductionProgramme.id}`);
-        cy.contains("a.govuk-button", "Edit year content").should("not.exist");
+      cy.get("@userData").then(([user]) => {
+        cy.appEval(`User.find("${user.id}").core_induction_programme`).then(
+          (cip) => {
+            cy.appEval(
+              `CoreInductionProgramme.find("${cip.id}").update!(course_year_one_id: "${year.id}")`
+            ).then(() => {
+              cy.visit(`/core-induction-programmes/${cip.id}`);
+              cy.contains("a.govuk-button", "Edit year content").should(
+                "not.exist"
+              );
+            });
+          }
+        );
       });
     });
   });

--- a/spec/policies/core_induction_programme_policy_spec.rb
+++ b/spec/policies/core_induction_programme_policy_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe CoreInductionProgrammePolicy, type: :policy do
   context "accessing cip views as an early career teacher" do
     let(:user) { create(:user, :early_career_teacher, { core_induction_programme: core_induction_programme }) }
     it { is_expected.to permit_action(:show) }
-    it { is_expected.not_to permit_action(:index) }
+    it { is_expected.to forbid_action(:index) }
   end
 
   context "being a visitor" do
     let(:user) { nil }
-    it { is_expected.not_to permit_action(:show) }
-    it { is_expected.not_to permit_action(:index) }
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:index) }
   end
 end

--- a/spec/policies/core_induction_programme_policy_spec.rb
+++ b/spec/policies/core_induction_programme_policy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoreInductionProgrammePolicy, type: :policy do
+  subject { described_class.new(user, core_induction_programme) }
+  let(:core_induction_programme) { create(:core_induction_programme) }
+
+  context "accessing show as early career teacher" do
+    let(:user) { create(:user, :early_career_teacher, { core_induction_programme: core_induction_programme }) }
+
+    it { is_expected.to permit_action(:show) }
+  end
+end

--- a/spec/policies/core_induction_programme_policy_spec.rb
+++ b/spec/policies/core_induction_programme_policy_spec.rb
@@ -6,9 +6,21 @@ RSpec.describe CoreInductionProgrammePolicy, type: :policy do
   subject { described_class.new(user, core_induction_programme) }
   let(:core_induction_programme) { create(:core_induction_programme) }
 
-  context "accessing show as early career teacher" do
-    let(:user) { create(:user, :early_career_teacher, { core_induction_programme: core_induction_programme }) }
-
+  context "accessing cip views as admin" do
+    let(:user) { create(:user, :admin) }
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index) }
+  end
+
+  context "accessing cip views as an early career teacher" do
+    let(:user) { create(:user, :early_career_teacher, { core_induction_programme: core_induction_programme }) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.not_to permit_action(:index) }
+  end
+
+  context "being a visitor" do
+    let(:user) { nil }
+    it { is_expected.not_to permit_action(:show) }
+    it { is_expected.not_to permit_action(:index) }
   end
 end

--- a/spec/requests/core_induction_programme/core_induction_programme_spec.rb
+++ b/spec/requests/core_induction_programme/core_induction_programme_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe "Core Induction Programme", type: :request do
         get "/core-induction-programmes/#{core_induction_programme.id}"
         expect(response).to render_template(:show)
       end
+
+      it "raises an error when an ECT tries to access a cip they are not enrolled on" do
+        second_core_induction_programme = create(:core_induction_programme)
+        expect { get "/core-induction-programmes/#{second_core_induction_programme.id}" }.to raise_error Pundit::NotAuthorizedError
+      end
     end
   end
 

--- a/spec/requests/core_induction_programme/core_induction_programme_spec.rb
+++ b/spec/requests/core_induction_programme/core_induction_programme_spec.rb
@@ -3,18 +3,56 @@
 require "rails_helper"
 
 RSpec.describe "Core Induction Programme", type: :request do
-  describe "GET /core-induction-programmes" do
-    it "renders the core_induction_programmes page" do
-      get "/core-induction-programmes"
-      expect(response).to render_template(:index)
+  let(:core_induction_programme) { create(:core_induction_programme) }
+
+  describe "when an admin user is logged in" do
+    before do
+      admin_user = create(:user, :admin)
+      sign_in admin_user
+    end
+
+    describe "GET /core-induction-programmes" do
+      it "renders the core_induction_programmes page" do
+        get "/core-induction-programmes"
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /core-induction-programmes/:id" do
+      it "renders the core_induction_programmes page" do
+        get "/core-induction-programmes/#{core_induction_programme.id}"
+        expect(response).to render_template(:show)
+      end
     end
   end
 
-  describe "GET /core-induction-programmes/:id" do
+  describe "when an early career teacher is logged in" do
+    before do
+      early_career_teacher = create(:user, :early_career_teacher, { core_induction_programme: core_induction_programme })
+      sign_in early_career_teacher
+    end
+
+    describe "GET /core-induction-programmes" do
+      it "raises an error trying to access core_induction_programme index page" do
+        expect { get "/core-induction-programmes" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "GET /core-induction-programmes/:id" do
+      it "renders the core_induction_programme show page" do
+        get "/core-induction-programmes/#{core_induction_programme.id}"
+        expect(response).to render_template(:show)
+      end
+    end
+  end
+
+  describe "being a visitor" do
+    it "raises an error trying to access core_induction_programme index page" do
+      expect { get "/core-induction-programmes" }.to raise_error Pundit::NotAuthorizedError
+    end
+
     it "renders the core_induction_programme show page" do
-      core_induction_programme = create(:core_induction_programme)
-      get "/core-induction-programmes/#{core_induction_programme.id}"
-      expect(response).to render_template(:show)
+      expect { get "/core-induction-programmes/#{core_induction_programme.id}" }.to raise_error Pundit::NotAuthorizedError
     end
   end
 

--- a/spec/requests/users/logout_spec.rb
+++ b/spec/requests/users/logout_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Users::Sessions", type: :request do
 
       get "/users/sign_out"
 
-      expect(response).to redirect_to(new_user_session_url)
+      expect(response).to redirect_to(root_path)
       expect(controller.current_user).to be_nil
       expect(flash[:notice]).to eq "Signed out successfully."
     end

--- a/spec/requests/users/logout_spec.rb
+++ b/spec/requests/users/logout_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Users::Sessions", type: :request do
 
       get "/users/sign_out"
 
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(new_user_session_url)
       expect(controller.current_user).to be_nil
       expect(flash[:notice]).to eq "Signed out successfully."
     end


### PR DESCRIPTION
### Context
We want to restrict access for ECTs so that they only have access to the cip they are enrolled on. 

### Changes proposed in this pull request
- Implement CoreInductionProgrammePolicy, restricting index to admin and show to only the cip the ect is enrolled on
- Additional test user ECT profiles. Each CIP has an ECT profile assigned to it.
- Logout now redirects to sign_in page.

### Guidance to review
The logout redirects to sign_in because we've restricted the index to admin only. root_url is also the index page so we may need to think about what the landing page is. 

### Testing
Additional tests have been included for the CoreInductionProgrammePolicy and requests.
