### PR TITLE
Reset db on re-deploy on dev

### DIFF
--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc "Remove all database content, then seed it. Only for dev environments."
+  task safe_reset: :environment do
+    if Rails.env.development? || Rails.env.deployed_development?
+      connection = ActiveRecord::Base.connection
+      tables = connection
+                   .execute("SELECT tablename FROM pg_catalog.pg_tables where schemaname='public';")
+                   .map { |row| row["tablename"] }
+      tables.delete "schema_migrations"
+      tables.delete "spatial_ref_sys"
+      tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
+      Rake::Task["db:seed"].invoke
+      puts "Re-seeded the database!"
+    else
+      puts "You should think twice before recreating staging or production database!"
+      puts "Fire off Rails console and copy the code from this task if you really have to."
+      puts "Make sure you know what you are doing and maybe do a back-up first."
+    end
+  end
+end

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -11,3 +11,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "standard"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && rails s"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,4 +10,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "standard"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:seed && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && rails s"


### PR DESCRIPTION
### Context
So dev environment gets purged every now and then - to keep it from getting too messy, and to automatically bring staging changes into it. 

### Changes proposed in this pull request
Add a rake task that only works in dev environments. The task deletes contents of our db and runs the seed files. 

Already done it on R&P. 