### PR TITLE
CPDEL-207: Confirm account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,18 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(user)
-    stored_location_for(user) || dashboard_url
+    stored_location_for(user) || login_dashboard_path(user)
   end
 
 protected
+
+  def login_dashboard_path(user)
+    if user.account_created
+      dashboard_path
+    else
+      new_username_path
+    end
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[email full_name])

--- a/app/controllers/username_controller.rb
+++ b/app/controllers/username_controller.rb
@@ -3,6 +3,13 @@
 class UsernameController < ApplicationController
   before_action :authenticate_user!
 
+  def new; end
+
+  def create
+    current_user.update!(user_params.merge(account_created: true))
+    redirect_to dashboard_path
+  end
+
   def edit; end
 
   def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,8 +39,4 @@ class User < ApplicationRecord
   def preferred_name
     username&.presence || full_name
   end
-
-  def dfe_confirmed?
-    true
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,17 +46,19 @@
           <nav aria-label="Page Navigation">
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <% if user_signed_in? %>
-              <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(dashboard_path) %>">
-                <%= govuk_link_to "Home", dashboard_path, class: "govuk-header__link" %>
-              </li>
-              <% if current_user.admin? %>
-                <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(cip_index_path) %>">
-                  <%= govuk_link_to "Core Induction Programme", cip_index_path, class: "govuk-header__link" %>
-                </li>
-              <% end %>
-              <li class="govuk-header__navigation-item">
-                <%= govuk_link_to "Logout", destroy_user_session_path, class: "govuk-header__link" %>
-              </li>
+                <% if current_user.account_created %>
+                  <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(dashboard_path) %>">
+                    <%= govuk_link_to "Home", dashboard_path, class: "govuk-header__link" %>
+                  </li>
+                  <% if current_user.admin? %>
+                    <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(cip_index_path) %>">
+                      <%= govuk_link_to "Core Induction Programme", cip_index_path, class: "govuk-header__link" %>
+                    </li>
+                  <% end %>
+                  <li class="govuk-header__navigation-item">
+                    <%= govuk_link_to "Logout", destroy_user_session_path, class: "govuk-header__link" %>
+                  </li>
+                <% end %>
               <% else %>
               <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
                 <%= govuk_link_to "Login", new_user_session_path, class: "govuk-header__link" %>

--- a/app/views/username/new.html.erb
+++ b/app/views/username/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: dashboard_path)
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Create a username</h1>
+
+    <%= form_with model: current_user, method: :post, url: username_path do |f| %>
+      <%= f.govuk_text_field :username, label: { text: "Username" }, width: "two-thirds" %>
+      <%= f.govuk_submit "Save" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/username/new.html.erb
+++ b/app/views/username/new.html.erb
@@ -9,7 +9,7 @@
 
     <%= form_with model: current_user, method: :post, url: username_path do |f| %>
       <%= f.govuk_text_field :username, label: { text: "Username" }, width: "two-thirds" %>
-      <%= f.govuk_submit "Save" %>
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -46,7 +46,7 @@ en:
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
     sessions:
-      signed_in: "Signed in successfully."
+      signed_in: ""
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   resource :cookies, only: %i[show update]
   resource :dashboard, controller: :dashboard, only: :show
-  resource :username, controller: :username, only: %i[edit update]
+  resource :username, controller: :username, only: %i[new create edit update]
 
   get "/403", to: "errors#forbidden", via: :all
   get "/404", to: "errors#not_found", via: :all

--- a/db/migrate/20210412150041_add_account_created_to_user.rb
+++ b/db/migrate/20210412150041_add_account_created_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAccountCreatedToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :account_created, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_113051) do
+ActiveRecord::Schema.define(version: 2021_04_12_150041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 2021_04_07_113051) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "username"
+    t.boolean "account_created", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     login_token { Faker::Alphanumeric.alpha(number: 10) }
     confirmed_at { 1.hour.ago }
     login_token_valid_until { 1.hour.from_now }
+    account_created { true }
 
     trait :admin do
       admin_profile { build(:admin_profile) }

--- a/spec/requests/username_request_spec.rb
+++ b/spec/requests/username_request_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Usernames", type: :request do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, account_created: false) }
 
   before do
     sign_in user

--- a/spec/requests/username_request_spec.rb
+++ b/spec/requests/username_request_spec.rb
@@ -9,10 +9,30 @@ RSpec.describe "Usernames", type: :request do
     sign_in user
   end
 
+  describe "GET /username/new" do
+    it "renders new template" do
+      get "/username/new"
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "POST /username" do
+    it "redirects to dashboard" do
+      post "/username", params: { user: { username: "Test" } }
+      expect(response).to redirect_to(dashboard_path)
+    end
+
+    it "sets username and account_created" do
+      post "/username", params: { user: { username: "Test" } }
+      expect(user.reload.account_created).to be_truthy
+      expect(user.username).to eq("Test")
+    end
+  end
+
   describe "GET /username/edit" do
-    it "returns http success" do
+    it "renders edit template" do
       get "/username/edit"
-      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:edit)
     end
   end
 
@@ -20,6 +40,11 @@ RSpec.describe "Usernames", type: :request do
     it "redirects successfully" do
       put "/username", params: { user: { username: "Test" } }
       expect(response).to redirect_to(dashboard_path)
+    end
+
+    it "sets username and account_created" do
+      post "/username", params: { user: { username: "Test" } }
+      expect(user.username).to eq("Test")
     end
   end
 end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users::Sessions", type: :request do
+  let(:user) { create(:user, account_created: true) }
+
+  describe "GET /users/sign_in" do
+    it "renders the sign in page" do
+      get "/users/sign_in"
+
+      expect(response).to render_template(:new)
+    end
+
+    context "when already signed in" do
+      before { sign_in user }
+
+      it "redirects to the dashboard" do
+        get "/users/sign_in"
+
+        expect(response).to redirect_to "/dashboard"
+      end
+    end
+  end
+
+  describe "POST /users/sign_in" do
+    context "when email matches a user" do
+      it "redirects to new username path when user has not created account" do
+        new_user = create(:user)
+        post "/users/sign_in", params: { user: { email: new_user.email } }
+        expect(response).to redirect_to(new_username_path)
+      end
+
+      it "redirects to dashboard when user has created account" do
+        post "/users/sign_in", params: { user: { email: user.email } }
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    context "when email doesn't match any user" do
+      let(:email) { Faker::Internet.email }
+      it "renders the login_email_sent template to prevent exposing information about user accounts" do
+        post "/users/sign_in", params: { user: { email: email } }
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Users::Sessions", type: :request do
   describe "POST /users/sign_in" do
     context "when email matches a user" do
       it "redirects to new username path when user has not created account" do
-        new_user = create(:user)
+        new_user = create(:user, account_created: false)
         post "/users/sign_in", params: { user: { email: new_user.email } }
         expect(response).to redirect_to(new_username_path)
       end


### PR DESCRIPTION
### Context
We want to ask the users to create a username on their first login - or rather, on every login until they complete the flow. 
JIRA ticket: https://dfedigital.atlassian.net/browse/CPDEL-207

### Changes proposed in this pull request
1. Add a flag to the user model checking whether they finished this lovely flow.
2. If yes, log them in as usual.
3. If not, log them in, and ask for username. 

### Guidance to review
I decided against using `confirmed` from devise - I think there is some magic surrounding it, and we will almost certainly end up discarding it.

Adding a flag to the db seemed like the easiest way of letting the users ignore username creation. If they want to they can press 'continue' and we will keep using their full name. And they will never see that flow again. 

### Testing
I added request specs.

Would be useful to check the behaviour matches expectations - we should have 4 fresh users to test with:
```
ambition-institute-early-career-teacher@example.com
education-development-trust-early-career-teacher@example.com
teach-first-early-career-teacher@example.com
ucl-early-career-teacher@example.com 
```

Cucumber tests will come in a later PR, when we cucumberise our setup. Soon, I promise. 