### PR TITLE
Cucumberise login tests and remove duplicate a11y tests 🥒

### DIFF
--- a/spec/cypress/integration/Login.feature
+++ b/spec/cypress/integration/Login.feature
@@ -1,0 +1,15 @@
+Feature: Login
+  All users should be able to login in
+
+  Scenario: ECT login
+    Given user was created as "early_career_teacher" with email "ect@example.com" and full_name "Demo User"
+    And I am on "sign in" page
+
+    When I type "nope@example.com" into "email input"
+    And I click the submit button
+    Then "error summary" should contain "Enter the email address your school used when they created your account"
+    And the page should be accessible
+
+    When I type "ect@example.com" into "email input"
+    And I click the submit button
+    Then "page heading" should contain "Welcome Demo User"

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -4,61 +4,6 @@ describe("Accessibility", () => {
     cy.checkA11y();
   });
 
-  it("Login should be accessible", () => {
-    cy.visit("/users/sign_in");
-    cy.checkA11y();
-
-    // School not registered page
-    cy.get('[name="user[email]"]').type("doesntexist@example.com{enter}");
-    cy.get(".govuk-error-summary").should(
-      "contain",
-      "Enter the email address your school used when they created your account"
-    );
-    cy.checkA11y();
-
-    cy.visit("/users/sign_in");
-    cy.checkA11y();
-
-    cy.appFactories([["create", "user", "early_career_teacher"]])
-      .as("userData")
-      .then(([user]) => {
-        cy.get('[name="user[email]"]').type(user.email);
-      });
-
-    cy.clickCommitButton();
-
-    cy.get("@userData").then(([user]) => {
-      cy.get("h1").should("contain", `Welcome ${user.full_name}`);
-    });
-
-    cy.checkA11y();
-  });
-
-  it("CIP should be accessible", () => {
-    cy.appFactories([["create", "core_induction_programme"]]);
-
-    cy.login("admin");
-
-    cy.visit("/core-induction-programmes");
-    cy.checkA11y();
-
-    cy.contains("Test Core induction programme").click();
-    cy.checkA11y();
-
-    cy.appFactories([["create", "course_lesson", "with_lesson_part"]]).as(
-      "courseLesson"
-    );
-    cy.get("@courseLesson").then(([lesson]) => {
-      cy.visitModuleOfLesson(lesson);
-
-      cy.contains("Test Course module").click();
-      cy.checkA11y();
-
-      cy.contains("Test Course lesson").click();
-      cy.checkA11y();
-    });
-  });
-
   it("Govspeak should be accessible", () => {
     cy.visit("/govspeak_test");
 

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -12,9 +12,11 @@ const elements = {
   "name input": '[name*="name"]',
   "title input": '[name*="title"]',
   "content input": '[name*="content"]',
+  "email input": '[name*="email"]',
   "time input": '[name*="time"]',
   "govspeak content": ".govuk-govspeak",
   "tag component": ".govuk-tag",
+  "error summary": ".govuk-error-summary",
 };
 
 const get = (element) => cy.get(elements[element] || element);

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -7,6 +7,7 @@ const pagePaths = {
   start: "/",
   dashboard: "/dashboard",
   "edit username": "/username/edit",
+  "sign in": "/users/sign_in",
   "core induction programme index": "/core-induction-programmes",
   "core induction programme year": "/core-induction-programmes/:id",
   "core induction programme year edit": "/years/:id/edit",


### PR DESCRIPTION
- Login is now cucumber specs
- CIP was already being tested (in the CIP admin stories)
- The remaining accessibility tests are too complicated to be turned into cucumber specs