### PR TITLE
Editing mentor materials

### DIFF
--- a/app/controllers/core_induction_programmes/mentor_materials_controller.rb
+++ b/app/controllers/core_induction_programmes/mentor_materials_controller.rb
@@ -33,8 +33,7 @@ private
   def load_mentor_material
     @mentor_material = MentorMaterial.find(params[:id])
     @core_induction_programmes = CoreInductionProgramme.all
-    # To do - remove or edit based on changes to models. @course_lessons is in the materials field view also.
-    # @course_lessons = CourseLesson.where(course_year: @mentor_material.core_induction_programme.course_years)
+    @course_lessons = @mentor_material.core_induction_programme&.course_lessons
     authorize @mentor_material
   end
 

--- a/app/controllers/core_induction_programmes/mentor_materials_controller.rb
+++ b/app/controllers/core_induction_programmes/mentor_materials_controller.rb
@@ -1,11 +1,44 @@
 # frozen_string_literal: true
 
 class CoreInductionProgrammes::MentorMaterialsController < ApplicationController
+  include Pundit
+
+  after_action :verify_authorized
+  before_action :authenticate_user!, except: :show
+  before_action :load_mentor_material, except: :index
+
   def index
     @mentor_materials = MentorMaterial.all
+    authorize MentorMaterial
   end
 
-  def show
+  def show; end
+
+  def edit; end
+
+  def update
+    @mentor_material.assign_attributes(mentor_material_params)
+
+    if params[:commit] == "Save changes"
+      @mentor_material.save!
+      flash[:success] = "Your changes have been saved"
+      redirect_to mentor_material_path
+    else
+      render action: "edit"
+    end
+  end
+
+private
+
+  def load_mentor_material
     @mentor_material = MentorMaterial.find(params[:id])
+    @core_induction_programmes = CoreInductionProgramme.all
+    # To do - remove or edit based on changes to models. @course_lessons is in the materials field view also.
+    # @course_lessons = CourseLesson.where(course_year: @mentor_material.core_induction_programme.course_years)
+    authorize @mentor_material
+  end
+
+  def mentor_material_params
+    params.require(:mentor_material).permit(:title, :content, :core_induction_programme_id, :course_lesson_id)
   end
 end

--- a/app/models/core_induction_programme.rb
+++ b/app/models/core_induction_programme.rb
@@ -11,4 +11,12 @@ class CoreInductionProgramme < ApplicationRecord
   def course_years
     [course_year_one, course_year_two].filter(&:present?)
   end
+
+  def course_modules
+    CourseModule.where(course_year: course_years)
+  end
+
+  def course_lessons
+    CourseLesson.where(course_module: course_modules)
+  end
 end

--- a/app/policies/mentor_material_policy.rb
+++ b/app/policies/mentor_material_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MentorMaterialPolicy < ApplicationPolicy
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def edit?
+    admin_only
+  end
+
+  def update?
+    admin_only
+  end
+end

--- a/app/views/core_induction_programmes/mentor_materials/_mentor_material_fields.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/_mentor_material_fields.html.erb
@@ -1,0 +1,19 @@
+<%= f.govuk_collection_select(
+      :core_induction_programme_id,
+      @core_induction_programmes,
+      :id,
+      :name,
+      label: { text: "Which core induction programme would you like to assign the mentor material to?" , class: "govuk-heading-m" }
+    ) %>
+<% if @course_lessons %>
+  <%= f.govuk_collection_select(
+        :course_lesson_id,
+        @course_lessons,
+        :id,
+        :title,
+        label: { text: "Which lesson would you like to assign the mentor material to?" , class: "govuk-heading-m" }
+      ) %>
+<% end %>
+<%= f.govuk_text_field :title, label: { text: "Mentor material title" }, value: @mentor_material.title %>
+<%= f.govuk_text_area :content, label: { text: "Markdown string for mentor material content" }, rows: 10, value: @mentor_material.content %>
+<%= f.govuk_submit "Save changes" %>

--- a/app/views/core_induction_programmes/mentor_materials/edit.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Content change preview</h1>
+    <%= form_with model: @mentor_material, url: mentor_material_path, method: :put do |f| %>
+      <%= render "mentor_material_fields", locals = { f:f } %>
+      <%= f.govuk_submit "See preview" %>
+    <% end %>
+    <div class="gem-c-govspeak govuk-govspeak ">
+      <%= @mentor_material.content_to_html.html_safe %>
+    </div>
+  </div>
+</div>

--- a/app/views/core_induction_programmes/mentor_materials/show.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/show.html.erb
@@ -1,5 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <% if policy(@mentor_material).edit? %>
+      <%= govuk_link_to "Edit mentor material", edit_mentor_material_path(@mentor_material), button: true %>
+    <% end %>
     <h1 class="govuk-heading-xl"><%= @mentor_material.title %></h1>
     <div class="gem-c-govspeak govuk-govspeak">
       <%= @mentor_material.content_to_html.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
       get "show_delete", to: "lesson_parts#show_delete"
     end
 
-    resources :mentor_materials, path: "mentor-materials", only: %i[show index]
+    resources :mentor_materials, path: "mentor-materials", only: %i[show index edit update]
   end
   root to: "start#index"
 

--- a/spec/cypress/integration/CipStoriesAdmin.feature
+++ b/spec/cypress/integration/CipStoriesAdmin.feature
@@ -84,3 +84,26 @@ Feature: Admin user interaction with Core Induction Programme
     Then "page body" should contain "Your changes have been saved"
     And "page body" should contain "Lesson part test title"
     And "page body" should contain "New content for lesson part"
+
+  Scenario: Can edit mentor materials
+    Given mentor_material was created with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
+    And I am on "core induction programme mentor material" page with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
+
+    When I click on "link" containing "Edit mentor material"
+    Then I should be on "core induction programme mentor material edit" page
+    And the page should be accessible
+    And percy should be sent snapshot
+
+    When I clear "title input"
+    And I type "New mentor material title" into "title input"
+    And I clear "content input"
+    And I type "New mentor material content" into "content input"
+    And I click on "button" containing "See preview"
+    Then "page heading" should contain "preview"
+    And "govspeak content" should contain "New mentor material content"
+
+    When I click on "button" containing "Save changes"
+    Then "page body" should contain "Your changes have been saved"
+    And "page body" should contain "New mentor material title"
+    And "page body" should contain "New mentor material content"
+    And the page should be accessible

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -16,6 +16,8 @@ const pagePaths = {
   "core induction programme lesson": "/lessons/:id",
   "core induction programme lesson edit": "/lessons/:id/edit",
   "core induction programme lesson part": "/lesson_parts/:id",
+  "core induction programme mentor material": "/mentor-materials/:id",
+  "core induction programme mentor material edit": "/mentor-materials/:id/edit",
   "training and support": "/training-and-support",
 };
 

--- a/spec/policies/mentor_material_policy_spec.rb
+++ b/spec/policies/mentor_material_policy_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MentorMaterialPolicy, type: :policy do
+  subject { described_class.new(user, mentor_material) }
+  let(:mentor_material) { create(:mentor_material) }
+
+  context "editing as admin" do
+    let(:user) { create(:user, :admin) }
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+  end
+
+  context "trying to edit as a user" do
+    let(:user) { create(:user) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_edit_and_update_actions }
+  end
+
+  context "being a visitor" do
+    let(:user) { nil }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_edit_and_update_actions }
+  end
+end

--- a/spec/requests/core_induction_programme/mentor_material_spec.rb
+++ b/spec/requests/core_induction_programme/mentor_material_spec.rb
@@ -4,18 +4,98 @@ require "rails_helper"
 
 RSpec.describe "Mentor materials", type: :request do
   let(:mentor_material) { create(:mentor_material) }
+  let(:mentor_material_path) { "/mentor-materials/#{mentor_material.id}" }
 
-  describe "index" do
-    it "renders index temlate" do
-      get "/mentor-materials"
-      expect(response).to render_template(:index)
+  describe "when an admin user is logged in" do
+    before do
+      admin_user = create(:user, :admin)
+      sign_in admin_user
+    end
+
+    describe "GET /mentor-materials" do
+      it "renders index template" do
+        get "/mentor-materials"
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /mentor-materials/:id" do
+      it "renders show template" do
+        get "/mentor-materials/#{mentor_material.id}"
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "PUT /mentor-materials/:id" do
+      it "redirects to the mentor materials" do
+        put mentor_material_path, params: { commit: "Save changes", mentor_material: { title: "New title" } }
+        expect(response).to redirect_to(mentor_material_path)
+        get mentor_material_path
+        expect(response.body).to include("New title")
+      end
+    end
+
+    describe "GET /mentor-materials/:id/edit" do
+      it "renders the mentor materials edit page" do
+        get "#{mentor_material_path}/edit", params: { mentor_material: { id: mentor_material.id } }
+        expect(response).to render_template(:edit)
+      end
     end
   end
 
-  describe "show" do
-    it "renders the core_induction_programme show page" do
-      get "/mentor-materials/#{mentor_material.id}"
-      expect(response).to render_template(:show)
+  describe "when a non-admin user is logged in" do
+    before do
+      user = create(:user)
+      sign_in user
+    end
+
+    describe "GET /mentor-materials" do
+      it "renders index template" do
+        get "/mentor-materials"
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /mentor-materials/:id" do
+      it "renders the mentor materials show page" do
+        get "/mentor-materials/#{mentor_material.id}"
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "GET /mentor-materials/:id/edit" do
+      it "raises an error when trying to access edit page" do
+        expect { get "#{mentor_material_path}/edit" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    describe "PUT /mentor-materials/:id" do
+      it "redirects to the sign in page" do
+        expect { put mentor_material_path, params: { commit: "Save changes", content: mentor_material.content } }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+  end
+
+  describe "when a non-user is accessing the mentor material page" do
+    describe "GET /mentor-materials" do
+      it "raises an error when trying to access mentor materials" do
+        get "/mentor-materials"
+        expect(mentor_material_path).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "GET /mentor-materials/:id/edit" do
+      it "redirects to the sign in page" do
+        get "#{mentor_material_path}/edit"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    describe "PUT /mentor-materials/:id" do
+      it "redirects to the sign in page" do
+        put mentor_material_path, params: { commit: "Save changes", content: mentor_material.content }
+        expect(response).to redirect_to("/users/sign_in")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
We want to be able to edit mentor materials.

### Changes proposed in this pull request
Add editing mentor materials for admin users. Add needed policies.

### Guidance to review
This is for internal use only - so we can fix any issues we run into. Closely follows editing all other content-related things.

### Testing
Unit testing. I think it makes sense to hold off cucumber tests until we have concrete user stories for them.

If you want to see it in action, login as admin, go to `/mentor-materials` in the url, click on a mentor material and you should see a green 'edit' button. 