### PR TITLE
Fix contents list shown at top of lesson parts

### DIFF
--- a/app/views/core_induction_programmes/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show.html.erb
@@ -23,9 +23,9 @@
     <% end %>
 
     <p class="govuk-body govuk-!-font-size-19 govuk-!-margin-bottom-2">Contents</p>
-    <ul class="govuk-list">
+    <ul class="govuk-list govuk-list--bullet">
       <% @course_lesson_part.course_lesson.course_lesson_parts_in_order.each do |part| %>
-        <li class="govuk-list--bullet">
+        <li>
           <% if part == @course_lesson_part %>
             <span><%= part.title %></span>
           <% else %>


### PR DESCRIPTION
### Context

- Incorrect markup used on govuk bulleted list

### Changes proposed in this pull request

- Use correct markup for govuk bulleted list displaying contents list at top of a lesson parts page

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/92580/117141598-a0ddd100-ada6-11eb-96eb-555bf13c30a8.png)

#### After
![image](https://user-images.githubusercontent.com/92580/117141605-a509ee80-ada6-11eb-9390-88327df84da7.png)

### Guidance to review

- Markup should adhere to govuk design system documented at https://design-system.service.gov.uk/styles/typography/#lists

### Testing

- Login as admin
- View a lesson part that has a contents section at the top
- Bulleted list should now align with the LHS