### PR TITLE
Create mentor materials as admin

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,7 +25,7 @@ KEY=$(
         perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'
     )
 
-if [ "$KEY" != "" && "$KEY" != "9bc07a3af02ce5950e977cab8b77210dc317832"]; then
+if [ "$KEY" != "" ]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
     echo "Please check your code and remove API keys."
     exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Yarn install
         run: npm i -g yarn && yarn
       - name: Set up Ruby
-        uses: ruby/setup-ruby@9bc07a3af02ce5950e977cab8b77210dc3178328
+        uses: ruby/setup-ruby@v1.70.1
         with:
           ruby-version: 2.7.2
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.70.1
         with:
           bundler-cache: true
 
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.70.1
         with:
           bundler-cache: true
 

--- a/app/controllers/core_induction_programmes/mentor_materials_controller.rb
+++ b/app/controllers/core_induction_programmes/mentor_materials_controller.rb
@@ -32,6 +32,7 @@ class CoreInductionProgrammes::MentorMaterialsController < ApplicationController
   def new
     authorize MentorMaterial
     @mentor_material = MentorMaterial.new
+    @course_lessons = CourseLesson.all
   end
 
   def create

--- a/app/controllers/core_induction_programmes/mentor_materials_controller.rb
+++ b/app/controllers/core_induction_programmes/mentor_materials_controller.rb
@@ -5,7 +5,8 @@ class CoreInductionProgrammes::MentorMaterialsController < ApplicationController
 
   after_action :verify_authorized
   before_action :authenticate_user!, except: :show
-  before_action :load_mentor_material, except: :index
+  before_action :load_mentor_material, only: %i[show edit update]
+  before_action :load_core_induction_materials, only: %i[edit update new create]
 
   def index
     @mentor_materials = MentorMaterial.all
@@ -19,20 +20,39 @@ class CoreInductionProgrammes::MentorMaterialsController < ApplicationController
   def update
     @mentor_material.assign_attributes(mentor_material_params)
 
-    if params[:commit] == "Save changes"
+    if params[:commit] == "Save"
       @mentor_material.save!
       flash[:success] = "Your changes have been saved"
       redirect_to mentor_material_path
     else
-      render action: "edit"
+      render :edit
+    end
+  end
+
+  def new
+    authorize MentorMaterial
+    @mentor_material = MentorMaterial.new
+  end
+
+  def create
+    authorize MentorMaterial
+    @mentor_material = MentorMaterial.new(mentor_material_params)
+    if @mentor_material.save
+      flash[:success] = "Mentor material created"
+      redirect_to mentor_material_path(@mentor_material)
+    else
+      render :new
     end
   end
 
 private
 
+  def load_core_induction_materials
+    @core_induction_programmes = CoreInductionProgramme.all
+  end
+
   def load_mentor_material
     @mentor_material = MentorMaterial.find(params[:id])
-    @core_induction_programmes = CoreInductionProgramme.all
     @course_lessons = @mentor_material.core_induction_programme&.course_lessons
     authorize @mentor_material
   end

--- a/app/policies/mentor_material_policy.rb
+++ b/app/policies/mentor_material_policy.rb
@@ -21,4 +21,12 @@ class MentorMaterialPolicy < ApplicationPolicy
   def update?
     admin_only
   end
+
+  def new?
+    admin_only
+  end
+
+  def create?
+    admin_only
+  end
 end

--- a/app/views/core_induction_programmes/mentor_materials/_mentor_material_fields.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/_mentor_material_fields.html.erb
@@ -1,3 +1,4 @@
+<%= f.govuk_error_summary %>
 <%= f.govuk_collection_select(
       :core_induction_programme_id,
       @core_induction_programmes,
@@ -16,4 +17,4 @@
 <% end %>
 <%= f.govuk_text_field :title, label: { text: "Mentor material title" }, value: @mentor_material.title %>
 <%= f.govuk_text_area :content, label: { text: "Markdown string for mentor material content" }, rows: 10, value: @mentor_material.content %>
-<%= f.govuk_submit "Save changes" %>
+<%= f.govuk_submit "Save" %>

--- a/app/views/core_induction_programmes/mentor_materials/index.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/index.html.erb
@@ -1,6 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-l">Mentor materials</h2>
+    <h1 class="govuk-heading-l">Mentor materials</h1>
+
+    <% if current_user&.admin? %>
+      <%= govuk_link_to "Create Mentor Material", new_mentor_material_path, button: true %>
+    <% end %>
+
     <% if @mentor_materials.any? %>
       <% @mentor_materials.each do |mentor_material| %>
         <p><%= govuk_link_to mentor_material.title, mentor_material_path(mentor_material) %></p>

--- a/app/views/core_induction_programmes/mentor_materials/new.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/new.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Create mentor material</h1>
+    <%= form_with model: @mentor_material, url: mentor_materials_path, method: :post do |f| %>
+      <%= render "mentor_material_fields", locals = { f:f } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       put "update-progress", to: "lesson_parts#update_progress", as: :update_progress
     end
 
-    resources :mentor_materials, path: "mentor-materials", only: %i[show index edit update]
+    resources :mentor_materials, path: "mentor-materials", only: %i[show index edit update new create]
   end
   root to: "start#index"
 

--- a/spec/cypress/integration/CipStoriesAdmin.feature
+++ b/spec/cypress/integration/CipStoriesAdmin.feature
@@ -84,18 +84,22 @@ Feature: Admin user interaction with Core Induction Programme
     And "page body" should contain "Lesson part test title"
     And "page body" should contain "New content for lesson part"
 
-  Scenario: Can edit lessons without lesson part
-    Given course_lesson was created with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
-    And I am on "core induction programme lesson" page with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
+  Scenario: Can create mentor materials
+    Given I am on "core induction programme mentor materials" page
 
-    When I click on "link" containing "Spring test course module"
-    Then I should be on "core induction programme module" page
+    When I click on "link" containing "Create Mentor Material"
+    Then I should be on "core induction programme mentor material new" page
     And the page should be accessible
     And percy should be sent snapshot
 
-    When I click on "link" containing "Test Course lesson 1"
-    Then I should be on "core induction programme lesson" page
-    And percy should be sent snapshot
+    When I type "New mentor material title" into "title input"
+    And I type "New mentor material content" into "content input"
+    And I click on "button" containing "Save"
+
+    Then "page body" should contain "Mentor material created"
+    And "page body" should contain "New mentor material title"
+    And "page body" should contain "New mentor material content"
+    And the page should be accessible
 
   Scenario: Can edit mentor materials
     Given mentor_material was created with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
@@ -114,7 +118,7 @@ Feature: Admin user interaction with Core Induction Programme
     Then "page heading" should contain "preview"
     And "govspeak content" should contain "New mentor material content"
 
-    When I click on "button" containing "Save changes"
+    When I click on "button" containing "Save"
     Then "page body" should contain "Your changes have been saved"
     And "page body" should contain "New mentor material title"
     And "page body" should contain "New mentor material content"
@@ -139,3 +143,16 @@ Feature: Admin user interaction with Core Induction Programme
     And "page heading" should contain "New content-less lesson"
     And "page body" should contain "Duration: 30 minutes"
     And the page should be accessible
+
+  Scenario: Can edit lessons without lesson part
+    Given course_lesson was created with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
+    And I am on "core induction programme lesson" page with id "a4dc302c-ab71-4d7b-a10a-3116a778e8d5"
+
+    When I click on "link" containing "Spring test course module"
+    Then I should be on "core induction programme module" page
+    And the page should be accessible
+    And percy should be sent snapshot
+
+    When I click on "link" containing "Test Course lesson 1"
+    Then I should be on "core induction programme lesson" page
+    And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -19,6 +19,8 @@ const pagePaths = {
   "core induction programme lesson": "/lessons/:id",
   "core induction programme lesson edit": "/lessons/:id/edit",
   "core induction programme lesson part": "/lesson_parts/:id",
+  "core induction programme mentor materials": "/mentor-materials",
+  "core induction programme mentor material new": "/mentor-materials/new",
   "core induction programme mentor material": "/mentor-materials/:id",
   "core induction programme mentor material edit": "/mentor-materials/:id/edit",
   "training and support": "/training-and-support",

--- a/spec/policies/mentor_material_policy_spec.rb
+++ b/spec/policies/mentor_material_policy_spec.rb
@@ -6,23 +6,27 @@ RSpec.describe MentorMaterialPolicy, type: :policy do
   subject { described_class.new(user, mentor_material) }
   let(:mentor_material) { create(:mentor_material) }
 
-  context "editing as admin" do
+  context "as admin" do
     let(:user) { create(:user, :admin) }
     it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_edit_and_update_actions }
+    it { is_expected.to permit_new_and_create_actions }
   end
 
-  context "trying to edit as a user" do
+  context "as a user" do
     let(:user) { create(:user) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:index) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
   end
 
-  context "being a visitor" do
+  context "as a visitor" do
     let(:user) { nil }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:index) }
     it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
   end
 end

--- a/spec/requests/core_induction_programme/mentor_material_spec.rb
+++ b/spec/requests/core_induction_programme/mentor_material_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Mentor materials", type: :request do
 
     describe "PUT /mentor-materials/:id" do
       it "redirects to the mentor materials" do
-        put mentor_material_path, params: { commit: "Save changes", mentor_material: { title: "New title" } }
+        put mentor_material_path, params: { commit: "Save", mentor_material: { title: "New title" } }
         expect(response).to redirect_to(mentor_material_path)
         get mentor_material_path
         expect(response.body).to include("New title")
@@ -39,6 +39,21 @@ RSpec.describe "Mentor materials", type: :request do
       it "renders the mentor materials edit page" do
         get "#{mentor_material_path}/edit", params: { mentor_material: { id: mentor_material.id } }
         expect(response).to render_template(:edit)
+      end
+    end
+
+    describe "GET /mentor-materials/new" do
+      it "renders new template" do
+        get "/mentor-materials/new"
+        expect(response).to render_template(:new)
+      end
+    end
+
+    describe "POST /mentor-materials" do
+      it "creates a mentor material" do
+        expect {
+          post mentor_materials_path, params: { mentor_material: { title: "New title", content: "new content" } }
+        }.to(change { MentorMaterial.count }.by(1))
       end
     end
   end
@@ -71,7 +86,7 @@ RSpec.describe "Mentor materials", type: :request do
 
     describe "PUT /mentor-materials/:id" do
       it "redirects to the sign in page" do
-        expect { put mentor_material_path, params: { commit: "Save changes", content: mentor_material.content } }.to raise_error Pundit::NotAuthorizedError
+        expect { put mentor_material_path, params: { commit: "Save", content: mentor_material.content } }.to raise_error Pundit::NotAuthorizedError
       end
     end
   end
@@ -93,7 +108,7 @@ RSpec.describe "Mentor materials", type: :request do
 
     describe "PUT /mentor-materials/:id" do
       it "redirects to the sign in page" do
-        put mentor_material_path, params: { commit: "Save changes", content: mentor_material.content }
+        put mentor_material_path, params: { commit: "Save", content: mentor_material.content }
         expect(response).to redirect_to("/users/sign_in")
       end
     end


### PR DESCRIPTION
### Context
After spending a while looking at mentor materials, I think we won't be able to migrate all of them automatically - some content is hard hard to split without also making it unhelpful, and for that content we will probably just want to input it by hand.

### Changes proposed in this pull request
Add the new and create endpoints, actions, policy, tests.
Add a sneaky improvement to github action name, so pre-commit hook can be nicer. I hope it works. 

### Guidance to review
Log in as admin. Go to `/mentor-materials` in the url. There should be a button for creating a new mentor material.

### Testing
I added request specs and cucumber tests.
