### PR TITLE
Show term in module title (hacky)

### DIFF
--- a/app/helpers/cip_breadcrumb_helper.rb
+++ b/app/helpers/cip_breadcrumb_helper.rb
@@ -43,7 +43,7 @@ private
   end
 
   def course_module_crumb(course_module)
-    [course_module.title, module_path(course_module)]
+    [course_module.term_and_title, module_path(course_module)]
   end
 
   def course_lesson_crumb(course_lesson)

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -55,7 +55,7 @@ class CourseModule < ApplicationRecord
   end
 
   def term_and_title
-    "#{term}: #{title}"
+    "#{term.capitalize} #{title.downcase}"
   end
 
   def check_previous_module_id

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -4,7 +4,7 @@
     <% if policy(@course_module).edit? %>
       <%= govuk_link_to "Edit module content", edit_module_path(@course_module), button: true%>
     <% end %>
-    <h1 class="govuk-heading-l"> <%= @course_module.title %></h1>
+    <h1 class="govuk-heading-l"> <%= @course_module.term_and_title %></h1>
 
     <% if current_user&.early_career_teacher? %>
       <div class="gem-c-govspeak govuk-govspeak ">

--- a/spec/cypress/integration/CipStoriesAdmin.feature
+++ b/spec/cypress/integration/CipStoriesAdmin.feature
@@ -46,7 +46,7 @@ Feature: Admin user interaction with Core Induction Programme
 
     When I click on "button" containing "Save changes"
     Then "page body" should contain "Your changes have been saved"
-    And "page body" should contain "New module title"
+    And "page body" should contain "Spring new module title"
     And "page body" should contain "New test module content"
     And the page should be accessible
 

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -34,7 +34,6 @@ Cypress.Commands.add("visitModuleOfLesson", (courseLesson) => {
     `CourseModule.find_by(id: "${courseLesson.course_module_id}")`
   ).then((courseModule) => {
     cy.visit(`/modules/${courseModule.id}`);
-    cy.get("h1").should("contain", courseModule.title);
   });
 });
 

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -30,7 +30,7 @@ describe CipBreadcrumbHelper, type: :helper do
 
   describe "#course_module_breadcrumbs" do
     let(:course_module) { create(:course_module, course_year: course_year) }
-    let(:course_module_crumb) { [course_module.title, "/modules/#{course_module.id}"] }
+    let(:course_module_crumb) { [course_module.term_and_title, "/modules/#{course_module.id}"] }
     let(:course_module_breadcrumb) { helper.course_module_breadcrumbs(user, course_module) }
 
     it "returns an array for the course module breadcrumb" do
@@ -44,14 +44,14 @@ describe CipBreadcrumbHelper, type: :helper do
 
     it "returns just the title for the end crumb when the action_name is show" do
       allow(helper).to receive(:action_name) { "show" }
-      expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], @year_crumb, course_module.title])
+      expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], @year_crumb, course_module.term_and_title])
     end
   end
 
   describe "#course_lesson_breadcrumbs" do
     let(:course_module) { create(:course_module, course_year: course_year) }
     let(:course_lesson) { create(:course_lesson, course_module: course_module) }
-    let(:course_module_crumb) { [course_module.title, "/modules/#{course_module.id}"] }
+    let(:course_module_crumb) { [course_module.term_and_title, "/modules/#{course_module.id}"] }
     let(:course_lesson_crumb) { [course_lesson.title, "/lessons/#{course_lesson.id}"] }
     let(:course_lesson_breadcrumb) { helper.course_lesson_breadcrumbs(user, course_lesson) }
 

--- a/spec/models/course_module_spec.rb
+++ b/spec/models/course_module_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CourseModule, type: :model do
     describe "course_modules" do
       it "returns the term and title of a course module" do
         course_module = FactoryBot.create(:course_module)
-        expect(course_module.term_and_title).to eq("spring: Test Course module")
+        expect(course_module.term_and_title).to eq("Spring test course module")
       end
     end
   end

--- a/spec/requests/core_induction_programme/course_module_spec.rb
+++ b/spec/requests/core_induction_programme/course_module_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Core Induction Programme Module", type: :request do
         put course_module_path, params: { commit: "Save changes", course_module: { title: "New title", previous_module_id: "" } }
         expect(response).to redirect_to(course_module_path)
         get course_module_path
-        expect(response.body).to include("New title")
+        expect(response.body).to include("Spring new title")
       end
 
       it "reassigns an existing modules previous module id when moved" do


### PR DESCRIPTION
### Context

This is a hack to make the titles match the wireframes, which say "First half-term: blabla" under an "Autumn" title in the year page and "Autumn first half-term: blabla" in the module page.

This is hopefully temporary - a quick fix to get in before user testing.

I've repurposed an existing method which was being used in the admin interface only:

![image](https://user-images.githubusercontent.com/472830/117662121-1d9df000-b197-11eb-8c8a-4bdb1f963acb.png)

### Guidance to review

### Testing

yes