### PR TITLE
CPDEL-422: Fix errors to radios not linking to bottom of the page

### DIFF
--- a/app/models/course_lesson_progress.rb
+++ b/app/models/course_lesson_progress.rb
@@ -7,7 +7,7 @@ class CourseLessonProgress < ApplicationRecord
     complete: "complete",
   }
 
-  validates :progress, presence: { message: "Select if you have finished the session" }
+  validates :progress, presence: { message: "Select if you have finished and understood the session" }
 
   belongs_to :course_lesson
   belongs_to :early_career_teacher_profile

--- a/app/views/core_induction_programmes/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show.html.erb
@@ -22,7 +22,7 @@
         <%= render "core_induction_programmes/lesson_parts/lesson_part_content" %>
 
         <%= f.govuk_radio_buttons_fieldset(:progress, legend: { text: "Have you understood this week’s topic materials?" }) do %>
-          <%= f.govuk_radio_button :progress, :complete, label: { text: "Yes, I’ve understood the topic materials and am ready to put my learning into practice in the classroom" } %>
+          <%= f.govuk_radio_button :progress, :complete, label: { text: "Yes, I’ve understood the topic materials and am ready to put my learning into practice in the classroom" }, link_errors: true %>
           <%= f.govuk_radio_button :progress, :in_progress, label: { text: "No, I’d like to spend more time on this topic" } %>
           <%= f.govuk_radio_divider %>
           <%= f.govuk_radio_button :progress, :to_do, label: { text: "I have not started this topic yet and was just browsing the materials" } %>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/CPDEL-422
There was a bug in progress input error - the error from summary was not taking the user to the actual error message when clicked. 
Also, change copy for https://dfedigital.atlassian.net/browse/CPDEL-433

### Changes proposed in this pull request
Use @asmega 's advice to pass a parameter to one of the radio buttons telling it to link the errors to it.

### Guidance to review
Log in as `ucl-early-career-teacher@example.com`, go to any lesson, go to last page part, select nothing and click the submit button. You should see an error. Click on the error in the summary at the top of the page. You should be taken to the radios at the bottom of the page.

### Testing
I am not sure how to test it. I guess in cucumber we could recreate this situation, and click on the error message in the summary, but is there a way in cypress to check that we have scrolled? @callumacrae 

Any other ideas? 