### PR TITLE
[CPDE-383] Sync users on sign in attempt

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+REGISTER_AND_PARTNER_URL=https://api.example.com

--- a/app/models/register_and_partner_api/user.rb
+++ b/app/models/register_and_partner_api/user.rb
@@ -2,8 +2,12 @@
 
 module RegisterAndPartnerApi
   class User < RegisterAndPartnerApi::Resource
-    property :id, type: :string
-    property :full_name, type: :string
-    property :email, type: :string
+    def self.path(_params = nil)
+      "users"
+    end
+
+    def self.table_name
+      "data"
+    end
   end
 end

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -10,8 +10,8 @@ module RegisterAndPartnerApi
       rescue JsonApiClient::Errors::ClientError
         # This is how the API responds when we run out of pages :/
       end
-    rescue JsonApiClient::Errors::ApiError
-      raise RegisterAndPartnerApi::SyncError
+    rescue StandardError
+      Rails.logger.warn("Failed to sync users")
     end
 
     def self.sync_users(users)

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -18,8 +18,14 @@ module RegisterAndPartnerApi
     end
 
     def self.sync_users(users)
-      # TODO: For each user, update that user, their profiles, their connections
-      # Preferably directly from the data received in here - I don't want to have another API request per user
+      users.each do |remote_user|
+        attributes = remote_user.attributes
+        user = ::User.find_or_initialize_by(id: attributes[:id]) do |u|
+          u.full_name = attributes[:full_name]
+          u.email = attributes[:email]
+        end
+        user.save!
+      end
     end
 
     private_class_method :sync_users

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -4,30 +4,43 @@ module RegisterAndPartnerApi
   class SyncUsers
     def self.perform
       # TODO: Add the last time we synced users, to avoid getting too many of them back
+      # TODO: Add pagination
       begin
         sync_users(RegisterAndPartnerApi::User.all)
       rescue JsonApiClient::Errors::ClientError
         # This is how the API responds when we run out of pages :/
       end
-
-      # TODO: Make sure it works
-      # RegisterAndPartnerApi::SyncCheck.set_last_sync(Time.zone.now)
     rescue JsonApiClient::Errors::ApiError
-      # TODO: Once the API is set up and working on R&P, uncomment that line
-      # raise RegisterAndPartnerApi::SyncError
+      raise RegisterAndPartnerApi::SyncError
     end
 
     def self.sync_users(users)
+      logger = Rails.logger
       users.each do |remote_user|
-        attributes = remote_user.attributes
-        user = ::User.find_or_initialize_by(id: attributes[:id]) do |u|
-          u.full_name = attributes[:full_name]
-          u.email = attributes[:email]
-        end
+        attributes = user_attributes_from(remote_user)
+
+        user = ::User.find_or_initialize_by(email: attributes[:email])
+        user.full_name = attributes[:full_name]
+
+        ect_profile = ::EarlyCareerTeacherProfile.find_or_initialize_by(user: user)
+        ect_profile.core_induction_programme = CoreInductionProgramme.find_by(name: attributes[:cip])
+
+        ect_profile.save!
         user.save!
+      rescue StandardError
+        logger.warn("Error saving user!")
       end
     end
 
-    private_class_method :sync_users
+    def self.user_attributes_from(user_from_api)
+      {
+        register_and_partner_id: user_from_api.attributes[:id],
+        full_name: user_from_api.attributes[:attributes][:full_name],
+        email: user_from_api.attributes[:attributes][:email],
+        cip: "UCL",
+      }
+    end
+
+    private_class_method :sync_users, :user_attributes_from
   end
 end

--- a/documentation/debugging_in_govpaas.md
+++ b/documentation/debugging_in_govpaas.md
@@ -37,7 +37,7 @@ First, ssh into the host instance
 
 Then, 
 
-`cd /app`
+`cd ../app`
 
 and finally
 

--- a/lib/devise/strategies/yolo_authenticatable.rb
+++ b/lib/devise/strategies/yolo_authenticatable.rb
@@ -30,7 +30,7 @@ module Devise
 
           user = User.find_by(email: email)
 
-          unless user
+          if !user && !Rails.env.test?
             RegisterAndPartnerApi::SyncUsers.perform
             user = User.find_by(email: email)
           end

--- a/lib/devise/strategies/yolo_authenticatable.rb
+++ b/lib/devise/strategies/yolo_authenticatable.rb
@@ -30,7 +30,7 @@ module Devise
 
           user = User.find_by(email: email)
 
-          if !user && !Rails.env.test?
+          unless user
             RegisterAndPartnerApi::SyncUsers.perform
             user = User.find_by(email: email)
           end

--- a/lib/devise/strategies/yolo_authenticatable.rb
+++ b/lib/devise/strategies/yolo_authenticatable.rb
@@ -30,6 +30,11 @@ module Devise
 
           user = User.find_by(email: email)
 
+          unless user
+            RegisterAndPartnerApi::SyncUsers.perform
+            user = User.find_by(email: email)
+          end
+
           if user.blank?
             user = User.new
             user.errors.add :email, "Enter the email address your school used when they registered your account"

--- a/spec/cypress/cypress_helper.rb
+++ b/spec/cypress/cypress_helper.rb
@@ -14,3 +14,9 @@ CypressOnRails::SmartFactoryWrapper.configure(
   ],
 )
 Webpacker.compile
+
+class RegisterAndPartnerApi::User
+  def self.all
+    []
+  end
+end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -1,14 +1,20 @@
 {
-  "users": [
+  "data": [
     {
-      "id": "f750b841-a97c-48b5-b29d-e758c7bdd7a1",
-      "full_name": "Induction Tutor",
-      "email": "induction-tutor@example.com"
+      "id": "65abf54c-c7c2-490b-9bcd-bbb4e0aab934",
+      "type": "user",
+      "attributes": {
+        "email": "lead-provider@example.com",
+        "full_name": "Lead Provider"
+      }
     },
     {
-      "id": "5b9fa4a4-35b5-4cf7-b3db-b3b395af7406",
-      "full_name": "LeadProvider User",
-      "email": "lead-provider@example.com"
+      "id": "d0c50384-ecb4-4950-839b-854ebc073ae9",
+      "type": "user",
+      "attributes": {
+        "email": "school-leader@example.com",
+        "full_name": "Induction Tutor"
+      }
     }
   ]
 }

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -1,0 +1,14 @@
+{
+  "users": [
+    {
+      "id": "f750b841-a97c-48b5-b29d-e758c7bdd7a1",
+      "full_name": "Induction Tutor",
+      "email": "induction-tutor@example.com"
+    },
+    {
+      "id": "5b9fa4a4-35b5-4cf7-b3db-b3b395af7406",
+      "full_name": "LeadProvider User",
+      "email": "lead-provider@example.com"
+    }
+  ]
+}

--- a/spec/lib/devise/strategies/yolo_authenticatable_spec.rb
+++ b/spec/lib/devise/strategies/yolo_authenticatable_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Devise::Strategies::YoloAuthenticatable do
+  let(:env) do
+    Rack::MockRequest.env_for("", params: { user: { email: "user@example.com" } })
+  end
+
+  subject { described_class.new(env) }
+
+  describe "#valid?" do
+    it "returns true" do
+      expect(subject.valid?).to be_truthy
+    end
+  end
+
+  describe "#authenticate!" do
+    context "when user does not exist" do
+      it "call RegisterAndPartnerApi::SyncUsers.perform" do
+        allow(RegisterAndPartnerApi::SyncUsers).to receive(:perform)
+
+        subject.authenticate!
+        expect(RegisterAndPartnerApi::SyncUsers).to have_received(:perform)
+      end
+    end
+  end
+end

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
               title: "new lesson title",
               ect_summary: "new ect summary",
               completion_time_in_minutes: "10",
-              course_module_id: create(:course_module).id,
+              course_module_id: course_module.id,
             },
           }
         }.to change(CourseLesson, :count).by(1)
@@ -106,7 +106,7 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
             title: "new lesson title",
             ect_summary: "new ect summary",
             completion_time_in_minutes: "10",
-            course_module_id: create(:course_module).id,
+            course_module_id: course_module.id,
           },
         }
 
@@ -120,7 +120,7 @@ RSpec.describe "Core Induction Programme Lesson", type: :request do
               title: "",
               ect_summary: "new ect summary",
               completion_time_in_minutes: "10",
-              course_module_id: create(:course_module).id,
+              course_module_id: course_module.id,
             },
           }
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -32,10 +32,33 @@ RSpec.describe "Users::Sessions", type: :request do
     end
 
     context "when email doesn't match any user" do
-      let(:email) { Faker::Internet.email }
-      it "renders the login_email_sent template to prevent exposing information about user accounts" do
-        post "/users/sign_in", params: { user: { email: email } }
-        expect(response).to render_template(:new)
+      before do
+        stub_request(:get, "https://api.example.com/api/v1/users.json")
+          .with(
+            headers: {
+              "Accept" => "application/json,*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "User-Agent" => "Faraday v1.3.0",
+            },
+          ).to_return(status: 200, body: file_fixture("api/users.json").read, headers: { content_type: "application/json" })
+      end
+
+      context "user does not exist on api" do
+        let(:email) { Faker::Internet.email }
+
+        it "renders the login_email_sent template to prevent exposing information about user accounts" do
+          post "/users/sign_in", params: { user: { email: email } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "user does exist in api" do
+        let(:email) { "induction-tutor@example.com" }
+
+        it "redirects to dashboard" do
+          post "/users/sign_in", params: { user: { email: user.email } }
+          expect(response).to redirect_to(dashboard_path)
+        end
       end
     end
   end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -32,17 +32,6 @@ RSpec.describe "Users::Sessions", type: :request do
     end
 
     context "when email doesn't match any user" do
-      before do
-        stub_request(:get, "https://api.example.com/api/v1/users.json")
-          .with(
-            headers: {
-              "Accept" => "application/json,*/*",
-              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-              "User-Agent" => "Faraday v1.3.0",
-            },
-          ).to_return(status: 200, body: file_fixture("api/users.json").read, headers: { content_type: "application/json" })
-      end
-
       context "user does not exist on api" do
         let(:email) { Faker::Internet.email }
 

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegisterAndPartnerApi::SyncUsers do
+  describe "::perform" do
+    before do
+      stub_request(:get, "https://api.example.com/api/v1/users.json")
+        .with(
+          headers: {
+            "Accept" => "application/json,*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "User-Agent" => "Faraday v1.3.0",
+          },
+        ).to_return(status: 200, body: file_fixture("api/users.json").read, headers: { content_type: "application/json" })
+    end
+
+    it "imports all users returned" do
+      expect {
+        described_class.perform
+      }.to change(User, :count).by(2)
+    end
+
+    it "does not create the users again" do
+      expect {
+        described_class.perform
+        described_class.perform
+      }.to change(User, :count).by(2)
+    end
+
+    it "creates users with correct attributes" do
+      described_class.perform
+
+      record = User.find("f750b841-a97c-48b5-b29d-e758c7bdd7a1")
+      expect(record.full_name).to eql("Induction Tutor")
+      expect(record.email).to eql("induction-tutor@example.com")
+    end
+  end
+end

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -4,17 +4,6 @@ require "rails_helper"
 
 RSpec.describe RegisterAndPartnerApi::SyncUsers do
   describe "::perform" do
-    before do
-      stub_request(:get, "https://api.example.com/api/v1/users.json")
-        .with(
-          headers: {
-            "Accept" => "application/json,*/*",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "User-Agent" => "Faraday v1.3.0",
-          },
-        ).to_return(status: 200, body: file_fixture("api/users.json").read, headers: { content_type: "application/json" })
-    end
-
     it "imports all users returned" do
       expect {
         described_class.perform
@@ -31,9 +20,8 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     it "creates users with correct attributes" do
       described_class.perform
 
-      record = User.find("f750b841-a97c-48b5-b29d-e758c7bdd7a1")
+      record = User.find_by(email: "school-leader@example.com")
       expect(record.full_name).to eql("Induction Tutor")
-      expect(record.email).to eql("induction-tutor@example.com")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,4 +94,16 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  # Stub Register and Partner users api
+  config.before(:each) do
+    stub_request(:get, "https://api.example.com/api/v1/users.json")
+        .with(
+          headers: {
+            "Accept" => "application/json,*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "User-Agent" => "Faraday v1.3.0",
+          },
+        ).to_return(status: 200, body: file_fixture("api/users.json").read, headers: { content_type: "application/json" })
+  end
 end


### PR DESCRIPTION
### Context

- User data needs to come from Register & Partner so users can login to view their course

### Changes proposed in this pull request

- Updated service so it can now sync existing users from existing Register & Partner api
- Extremely naive implementation where we sync users when a user attempts to login and they do not exist in our database

### Guidance to review

- Not sure if this will work if deployed. ENV vars will probably need to be setup and point to dev Register & Partner
- There will be syncing issues if users change email addresses to existing ones due to validation. Should probably raise a ticket to resolve in the future

### Testing

- update `.env.development` and set `REGISTER_AND_PARTNER_URL` to the dev instance of Register & Partner
- Attempt to sign in as a user that exists on that api endpoint and not your local system
- Should create the user and you should be signed in