### PR TITLE
[CPDEL-454] Add reg and partner field to user

### DIFF
--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -19,7 +19,8 @@ module RegisterAndPartnerApi
       users.each do |remote_user|
         attributes = user_attributes_from(remote_user)
 
-        user = ::User.find_or_initialize_by(email: attributes[:email])
+        user = ::User.find_or_initialize_by(register_and_partner_id: attributes[:register_and_partner_id])
+        user.email = attributes[:email]
         user.full_name = attributes[:full_name]
 
         ect_profile = ::EarlyCareerTeacherProfile.find_or_initialize_by(user: user)
@@ -40,7 +41,6 @@ module RegisterAndPartnerApi
         cip: "UCL",
       }
     end
-
     private_class_method :sync_users, :user_attributes_from
   end
 end

--- a/db/migrate/20210520144310_add_register_and_partner_id_to_users.rb
+++ b/db/migrate/20210520144310_add_register_and_partner_id_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRegisterAndPartnerIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :register_and_partner_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_105706) do
+ActiveRecord::Schema.define(version: 2021_05_20_144310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_105706) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "preferred_name"
     t.boolean "account_created", default: false
+    t.uuid "register_and_partner_id"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -15,6 +15,14 @@
         "email": "school-leader@example.com",
         "full_name": "Induction Tutor"
       }
+    },
+    {
+      "id": "65abf54c-c7c2-490b-9bcd-bbb4e0aab934",
+      "type": "user",
+      "attributes": {
+        "email": "lead-provider-1@example.com",
+        "full_name": "Lead Provider"
+      }
     }
   ]
 }

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -15,14 +15,6 @@
         "email": "school-leader@example.com",
         "full_name": "Induction Tutor"
       }
-    },
-    {
-      "id": "65abf54c-c7c2-490b-9bcd-bbb4e0aab934",
-      "type": "user",
-      "attributes": {
-        "email": "lead-provider-1@example.com",
-        "full_name": "Lead Provider"
-      }
     }
   ]
 }

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     end
 
     it "updates an existing user that has changed their email address" do
+      create(:user, register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934", email: "lead-provider-1@example.com")
+
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
       expect(User.count).to eql(2)
-      expect(record.email).to eql("lead-provider-1@example.com")
+      expect(record.email).to eql("lead-provider@example.com")
     end
   end
 end

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -23,5 +23,13 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
       record = User.find_by(email: "school-leader@example.com")
       expect(record.full_name).to eql("Induction Tutor")
     end
+
+    it "updates an existing user that has changed their email address" do
+      described_class.perform
+
+      record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
+      expect(User.count).to eql(2)
+      expect(record.email).to eql("lead-provider-1@example.com")
+    end
   end
 end


### PR DESCRIPTION
### Context
Users in register and partner can change their email address. However this is what we're currently using to check if they exist on our service. R&P send us the users id so we can store this on our side, avoiding us creating duplicate users. [Jira ticket](https://dfedigital.atlassian.net/browse/CPDEL-454)

### Changes proposed in this pull request
Migration to add `register_and_partner_id` to Users table
Changes sync_users method to find user by their register_and_partner_id

### Guidance to review
Having the same user in the users.json file but with a changed email feels like cheating but i couldn't find a simpler way of testing the email updated. 

### Testing
Additional test for making sure the user isn't created twice and their email is updated. As above with the cheating. 

You could try it manually by following [these steps](https://github.com/DFE-Digital/ecf-engage-and-learn/blob/develop/documentation/register_and_partner_api_setup.md#developing-against-a-local-rp) to get the API running. Once you've done that, login on engage and learn with `lead-provider@example.com`. Change the `lead-provider@example.com` email address in your local R&P db, try to login with this new email on engage and learn and it should still work. The new email should also be stored on the engage and learn side.
