### PR TITLE
Update user sync

### DIFF
--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -2,6 +2,19 @@
 
 module RegisterAndPartnerApi
   class SyncUsers
+    USER_TYPES = {
+      ect: "early_career_teacher",
+      mentor: "mentor",
+    }.freeze
+
+    CIP_TYPES = {
+      ambition: "Ambition Institute",
+      edt: "Education Development Trust",
+      teach_first: "Teach First",
+      ucl: "UCL",
+      none: "none",
+    }.freeze
+
     def self.perform
       # TODO: Add the last time we synced users, to avoid getting too many of them back
       # TODO: Add pagination
@@ -19,15 +32,13 @@ module RegisterAndPartnerApi
       users.each do |remote_user|
         attributes = user_attributes_from(remote_user)
 
-        user = ::User.find_or_initialize_by(register_and_partner_id: attributes[:register_and_partner_id])
-        user.email = attributes[:email]
-        user.full_name = attributes[:full_name]
+        case attributes[:user_type]
+        when USER_TYPES[:ect]
+          find_or_create_user(attributes, ::EarlyCareerTeacherProfile)
+        when USER_TYPES[:mentor]
+          find_or_create_user(attributes, ::MentorProfile)
+        end
 
-        ect_profile = ::EarlyCareerTeacherProfile.find_or_initialize_by(user: user)
-        ect_profile.core_induction_programme = CoreInductionProgramme.find_by(name: attributes[:cip])
-
-        ect_profile.save!
-        user.save!
       rescue StandardError
         logger.warn("Error saving user!")
       end
@@ -38,9 +49,46 @@ module RegisterAndPartnerApi
         register_and_partner_id: user_from_api.attributes[:id],
         full_name: user_from_api.attributes[:attributes][:full_name],
         email: user_from_api.attributes[:attributes][:email],
-        cip: "UCL",
+        user_type: user_from_api.attributes[:attributes][:user_type],
+        cip: user_from_api.attributes[:attributes][:core_induction_programme],
       }
     end
-    private_class_method :sync_users, :user_attributes_from
+
+    def self.determine_core_induction_programme(cip_name)
+      case cip_name
+      when "ambition"
+        CIP_TYPES[:ambition]
+      when "edt"
+        CIP_TYPES[:edt]
+      when "teach_first"
+        CIP_TYPES[:teach_first]
+      when "ucl"
+        CIP_TYPES[:ucl]
+      end
+    end
+
+    def self.find_or_create_user(attributes, profile_class)
+      user = ::User.find_or_initialize_by(register_and_partner_id: attributes[:register_and_partner_id])
+      profile = profile_class.find_or_initialize_by(user: user)
+
+      save_user_email_and_full_name(attributes, user)
+      save_profile_core_induction_programme(attributes, profile)
+    end
+
+    def self.save_user_email_and_full_name(attributes, user)
+      user.email = attributes[:email]
+      user.full_name = attributes[:full_name]
+      user.save!
+    end
+
+    def self.save_profile_core_induction_programme(attributes, profile)
+      profile.core_induction_programme = CoreInductionProgramme.find_by(
+        name: determine_core_induction_programme(attributes[:cip]),
+      )
+      profile.save!
+    end
+
+    private_class_method :sync_users, :user_attributes_from, :save_profile_core_induction_programme,
+                         :determine_core_induction_programme, :save_user_email_and_full_name, :find_or_create_user
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -5,7 +5,9 @@
       "type": "user",
       "attributes": {
         "email": "lead-provider@example.com",
-        "full_name": "Lead Provider"
+        "full_name": "Lead Provider",
+        "user_type": "mentor",
+        "core_induction_programme": "ucl"
       }
     },
     {
@@ -13,7 +15,29 @@
       "type": "user",
       "attributes": {
         "email": "school-leader@example.com",
-        "full_name": "Induction Tutor"
+        "full_name": "Induction Tutor",
+        "user_type": "mentor",
+        "core_induction_programme": "ucl"
+      }
+    },
+    {
+      "id": "26cb7f92-333d-4503-8d5d-817ef5d9563b",
+      "type": "user",
+      "attributes": {
+        "email": "rp-ect-ambition@example.com",
+        "full_name": "Joe Bloggs",
+        "user_type": "early_career_teacher",
+        "core_induction_programme": "ambition"
+      }
+    },
+    {
+      "id": "47dc8g13-444e-5614-9e6e-928fg6e1674c",
+      "type": "user",
+      "attributes": {
+        "email": "user_type_other@example.com",
+        "full_name": "Jane Doe",
+        "user_type": "other",
+        "core_induction_programme": "ucl"
       }
     }
   ]

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -7,14 +7,22 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     it "imports all users returned" do
       expect {
         described_class.perform
-      }.to change(User, :count).by(2)
+      }.to change(User, :count).by(3)
     end
 
     it "does not create the users again" do
       expect {
         described_class.perform
         described_class.perform
-      }.to change(User, :count).by(2)
+      }.to change(User, :count).by(3)
+    end
+
+    it "does not create a user when given a user type of other" do
+      described_class.perform
+
+      record = User.find_by(email: "user_type_other@example.com")
+      expect(record.nil?).to be true
+      expect(User.count).to eql(3)
     end
 
     it "creates users with correct attributes" do
@@ -24,13 +32,20 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
       expect(record.full_name).to eql("Induction Tutor")
     end
 
+    it "creates a user with a type of early_career_teacher" do
+      described_class.perform
+
+      record = User.find_by(email: "rp-ect-ambition@example.com")
+      expect(record.early_career_teacher?).to be true
+    end
+
     it "updates an existing user that has changed their email address" do
       create(:user, register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934", email: "lead-provider-1@example.com")
 
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
-      expect(User.count).to eql(2)
+      expect(User.count).to eql(3)
       expect(record.email).to eql("lead-provider@example.com")
     end
   end


### PR DESCRIPTION
### Context
We can now receive the type of user and their cip from the R&P api. We want to use this to create the right profile and assign their cip to them on E&L.

### Changes proposed in this pull request
Updated user sync method that creates a users profile based on the user_type sent and assigns them a cip based on the cip_type. 

### Guidance to review
We're currently only doing this for ECTs as we only receive a type of `early_career_teacher` and `other`. The other type will create a mentor profile. 

See [R&P PR](https://github.com/DFE-Digital/early-careers-framework/pull/400) for further info on the changes made on their side to see how what data is being sent and how it's selected. An enum is used for sending CIP_TYPE and USER_TYPE

### Testing
A couple changes to the sync_users_spec and an additional test to check user type. 