### PR TITLE
Update lesson and module show views

### DIFF
--- a/app/views/core_induction_programmes/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show.html.erb
@@ -17,6 +17,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if current_user&.mentor? %>
+      <span class="govuk-caption-l">The teacher's self-study materials</span>
+    <% end %>
     <% if policy(@course_lesson_part.course_lesson).update_progress? && @course_lesson_part.next_lesson_part.nil? %>
       <%= form_with model: @lesson_progress, url: lesson_part_update_progress_path(lesson_part_id: @course_lesson_part.id), method: :put do |f| %>
         <%= f.govuk_error_summary %>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -35,10 +35,16 @@
 
           <% if lesson.course_lesson_parts.any? %>
             <div class="app-task-list__section">
-              <%= govuk_link_to "Work through the self-study material#{
-                  lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
-                }", lesson_path(lesson) %>
-              <%= render ProgressLabelComponent.new progress: lesson.progress %>
+
+               <% if current_user&.early_career_teacher? %>
+                 <%= govuk_link_to "Work through the self-study material#{
+                    lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
+                  }", lesson_path(lesson) %>
+                 <%= render ProgressLabelComponent.new progress: lesson.progress %>
+               <% else %>
+                  <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
+               <% end %>
+
             </div>
           <% end %>
         </li>

--- a/app/webpacker/styles/app_task_list.scss
+++ b/app/webpacker/styles/app_task_list.scss
@@ -18,7 +18,6 @@
   width: 100%;
   padding-top: 20px;
   padding-bottom: 20px;
-  border-top: 1px solid $govuk-border-colour;
   border-bottom: 1px solid $govuk-border-colour;
 }
 


### PR DESCRIPTION
### Context

[Jira ticket 423](https://dfedigital.atlassian.net/browse/CPDEL-423)
[Jira ticket 481](https://dfedigital.atlassian.net/browse/CPDEL-481)

### Changes proposed in this pull request

Everyone except an ECT will see a link captioned View the teacher's self-study materials. ECT's see the same as before 'Work through the self-study materials

![Screenshot 2021-05-25 at 10 59 44 (2)](https://user-images.githubusercontent.com/69353998/119479309-6bdef180-bd48-11eb-83d6-06ca332420b1.png)
![Screenshot 2021-05-25 at 10 59 03 (2)](https://user-images.githubusercontent.com/69353998/119479359-77cab380-bd48-11eb-8753-f95780824eac.png)

### Guidance to review

Kam and Mark A discussed about Ambition, TF and UCL all having the same caption. Mark was happy to use the same for all 3. EDT is also using the same for now until there's been a firm decision made on how to show ECT materials.  

### Testing
None
