### PR TITLE
Update PR template and add ids to forms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,19 +6,16 @@ We want to xxx because yyy.
 
 ## Code review
 
-### What does this PR change in code?
-1. Change xxx in yyy
-
 ### Is there anything weird that code reviewer should know?
 Nope, everything is straightforward.
 
 ### Review Checks
-- [ ] All model methods are unit-tested via model specs
-- [ ] All controller actions are unit-tested via request specs
-- [ ] All pages have automated accessibility checks via cypress
-- [ ] All pages have visual tests via cypress + percy
+- [ ] All commit messages are meaningful and true
+- [ ] Added enough automated tests
 - [ ] All forms have an `id` attribute on them
 
 ## Product review
 
 ### How can someone see it it review app?
+1. Click the link to review app (posted by a `github-actions` bot below)
+2. Do something

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 Ticket:
 
-We want to xxx because yyy.
-
 ## Code review
 
 ### Is there anything weird that code reviewer should know?
@@ -18,4 +16,4 @@ Nope, everything is straightforward.
 
 ### How can someone see it it review app?
 1. Click the link to review app (posted by a `github-actions` bot below)
-2. Do something
+2. Follow the steps from the ticket.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,24 @@
-### Context
+## Ticket and context
 
-### Changes proposed in this pull request
+Ticket:
 
-### Guidance to review
+We want to xxx because yyy.
 
-### Testing
+## Code review
+
+### What does this PR change in code?
+1. Change xxx in yyy
+
+### Is there anything weird that code reviewer should know?
+Nope, everything is straightforward.
+
+### Review Checks
+- [ ] All model methods are unit-tested via model specs
+- [ ] All controller actions are unit-tested via request specs
+- [ ] All pages have automated accessibility checks via cypress
+- [ ] All pages have visual tests via cypress + percy
+- [ ] All forms have an `id` attribute on them
+
+## Product review
+
+### How can someone see it it review app?

--- a/app/views/cookies/_banner.html.erb
+++ b/app/views/cookies/_banner.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <%= form_with url: cookies_path, class: "js-cookie-form", method: :put do |f| %>
+    <%= form_with url: cookies_path, class: "js-cookie-form", method: :put, id: "cookie-form" do |f| %>
       <div class="govuk-button-group">
         <button type="submit" class="govuk-button" name="cookies_form[analytics_consent]" value="on">
           Accept analytics cookies

--- a/app/views/core_induction_programmes/lesson_parts/edit.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
     <%= govuk_link_to "Delete lesson part", lesson_part_show_delete_path(lesson_part_id: @course_lesson_part.id), button: true, class: "govuk-button--secondary"  %>
-    <%= form_with url: lesson_part_path, method: :put do |f| %>
+    <%= form_with url: lesson_part_path, method: :put, id: "course-lesson-part-update-form" do |f| %>
       <%= f.govuk_text_field :title, label: { text: "Lesson title" }, value: @course_lesson_part.title %>
       <%= f.govuk_text_area :content, label: { text: "Markdown string for course lesson content" }, rows: 10, value: @course_lesson_part.content %>
 

--- a/app/views/core_induction_programmes/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show.html.erb
@@ -21,7 +21,7 @@
       <span class="govuk-caption-l">The teacher's self-study materials</span>
     <% end %>
     <% if policy(@course_lesson_part.course_lesson).update_progress? && @course_lesson_part.next_lesson_part.nil? %>
-      <%= form_with model: @lesson_progress, url: lesson_part_update_progress_path(lesson_part_id: @course_lesson_part.id), method: :put do |f| %>
+      <%= form_with model: @lesson_progress, url: lesson_part_update_progress_path(lesson_part_id: @course_lesson_part.id), method: :put, id: "lesson-progress-form" do |f| %>
         <%= f.govuk_error_summary %>
 
         <%= render "core_induction_programmes/lesson_parts/lesson_part_content" %>

--- a/app/views/core_induction_programmes/lesson_parts/show_delete.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show_delete.html.erb
@@ -8,7 +8,7 @@
     </div>
     <p>You can return to <b><%= @course_lesson_part.course_lesson.title %></b> without making any changes by clicking cancel</p>
     <div class="govuk-button-group">
-      <%= form_with url: lesson_part_path(@course_lesson_part), method: :delete do |f| %>
+      <%= form_with url: lesson_part_path(@course_lesson_part), method: :delete, id: "course-lesson-part-delete-form" do |f| %>
         <%= f.govuk_submit "Delete", warning: true %>
         <%= govuk_link_to "Cancel", lesson_part_path(@course_lesson_part), class: "govuk-!-margin-top-2"%>
       <% end %>

--- a/app/views/core_induction_programmes/lesson_parts/show_split.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show_split.html.erb
@@ -32,7 +32,7 @@
 </div>
 
 <div class="outside-content-wrapper">
-  <%= form_with model: @split_lesson_part_form, url: lesson_part_split_path, method: :post do |f| %>
+  <%= form_with model: @split_lesson_part_form, url: lesson_part_split_path, method: :post, id: "course-lesson-part-split-form" do |f| %>
     <%= f.govuk_error_summary %>
 
     <div class="govuk-grid-row">

--- a/app/views/core_induction_programmes/lessons/edit.html.erb
+++ b/app/views/core_induction_programmes/lessons/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Edit lesson</h1>
 
-    <%= form_with model: @course_lesson, url: lesson_path, method: :put do |f| %>
+    <%= form_with model: @course_lesson, url: lesson_path, method: :put, id: "course-lesson-update-form" do |f| %>
       <%= render LessonNewPositionComponent.new(lesson: f.object, form: f) %>
 
       <%= render "course_lesson_fields", { f: f } %>

--- a/app/views/core_induction_programmes/lessons/new.html.erb
+++ b/app/views/core_induction_programmes/lessons/new.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Create lesson</h1>
-    <%= form_with model: @course_lesson, url: cip_create_lesson_path(@cip) do |f| %>
+    <%= form_with model: @course_lesson, url: cip_create_lesson_path(@cip), id: "course-lesson-create-form" do |f| %>
       <%= render "course_lesson_fields", { f: f } %>
     <% end %>
   </div>

--- a/app/views/core_induction_programmes/mentor_materials/edit.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
-    <%= form_with model: @mentor_material, url: mentor_material_path, method: :put do |f| %>
+    <%= form_with model: @mentor_material, url: mentor_material_path, method: :put, id: "mentor-materials-update-form" do |f| %>
       <%= render "mentor_material_fields", locals = { f:f } %>
       <%= f.govuk_submit "See preview" %>
     <% end %>

--- a/app/views/core_induction_programmes/mentor_materials/new.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/new.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Create mentor material</h1>
-    <%= form_with model: @mentor_material, url: mentor_materials_path, method: :post do |f| %>
+    <%= form_with model: @mentor_material, url: mentor_materials_path, method: :post, id: "mentor-materials-create-form" do |f| %>
       <%= render "mentor_material_fields", locals = { f:f } %>
     <% end %>
   </div>

--- a/app/views/core_induction_programmes/modules/edit.html.erb
+++ b/app/views/core_induction_programmes/modules/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
-    <%= form_with model:@course_module, url: module_path, method: :put do |f| %>
+    <%= form_with model:@course_module, url: module_path, method: :put, id: "course-year-update-form" do |f| %>
       <%= render "course_module_fields", locals = { f:f } %>
       <%= f.govuk_submit "See preview" %>
     <% end %>

--- a/app/views/core_induction_programmes/modules/new.html.erb
+++ b/app/views/core_induction_programmes/modules/new.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Create an additional course module</h1>
-    <%= form_with model: @course_module, url: cip_create_module_path, method: :post do |f| %>
+    <%= form_with model: @course_module, url: cip_create_module_path, method: :post, id: "course-module-create-form" do |f| %>
     <%= render "course_module_fields", locals = { f:f } %>
     <% end %>
   </div>

--- a/app/views/core_induction_programmes/years/edit.html.erb
+++ b/app/views/core_induction_programmes/years/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Content change preview</h1>
-    <%= form_with model: @course_year, url: year_path, method: :put do |f| %>
+    <%= form_with model: @course_year, url: year_path, method: :put, id: "course-year-update-form" do |f| %>
       <%= f.govuk_text_field :title, label: { text: "Year title" }, value: @course_year.title %>
       <%= f.govuk_text_field :mentor_title, label: { text: "Mentor year title" }, hint: { text: "This will override the title for mentors if specified" }, value: @course_year.mentor_title %>
       <%= f.govuk_text_area :content, label: { text: "Markdown string for course year content" }, rows: 10, value: @course_year.content %>

--- a/app/views/core_induction_programmes/years/new.html.erb
+++ b/app/views/core_induction_programmes/years/new.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Create an additional course year</h1>
-    <%= form_with model: @course_year, url: years_path, method: :post do |f| %>
+    <%= form_with model: @course_year, url: years_path, method: :post, id: "course-year-create-form" do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
             :core_induction_programme,

--- a/app/views/govspeak_test/show.html.erb
+++ b/app/views/govspeak_test/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Govspeak dev test</h1>
-    <%= form_with url: '/govspeak_test', method: :post do |f| %>
+    <%= form_with url: '/govspeak_test', method: :post, id: "govspeak-test-form" do |f| %>
       <%= f.govuk_text_area :preview_string, label: { text: "Markdown string to preview" }, rows: 10, value: @preview_string %>
       <%= f.govuk_submit "See preview" %>
     <% end %>

--- a/app/views/preferred_name/edit.html.erb
+++ b/app/views/preferred_name/edit.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Edit your name</h1>
 
-    <%= form_with model: current_user, url: preferred_name_path do |f| %>
+    <%= form_with model: current_user, url: preferred_name_path, id: "preferred-name-form" do |f| %>
       <%= f.govuk_text_field :preferred_name,
         label: { text: "What is your preferred name?" },
         hint: { text: "For example, Jess rather than Jessica." },


### PR DESCRIPTION
### Context
I think the PR template could use a makeover.

Also, Chris is keen on adding ids to forms, and shockingly Rails doesn't do that by itself, unless you use `form_for`, which seems to be a somewhat old tag, that is likely to be removed at some point in future (https://stackoverflow.com/questions/43868976/rails-5-form-for-vs-form-with)
