### PR TITLE
CPDEL 506 add cookie link in footer

### DIFF
--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -33,7 +33,7 @@
       </thead>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_govuk_rails_boilerplate_session</td>
+          <td class="govuk-table__cell">_support_for_early_career_teachers_session</td>
           <td class="govuk-table__cell" width="50%">Used to keep you signed in</td>
           <td class="govuk-table__cell">2 weeks</td>
         </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -102,6 +102,12 @@
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <%= render "layouts/support_links" %>
 
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <%= govuk_link_to "Cookies", cookies_path, class:"govuk-footer__link"  %>
+              </li>
+            </ul>
+
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
               />

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.session_store :cookie_store, key: "_govuk_rails_boilerplate_session", secure: true, expire_after: 2.weeks
+  config.session_store :cookie_store, key: "_support_for_early_career_teachers_session", secure: true, expire_after: 2.weeks
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.session_store :cookie_store, key: "_govuk_rails_boilerplate_session", secure: true, expire_after: 2.weeks
+  config.session_store :cookie_store, key: "_support_for_early_career_teachers_session", secure: true, expire_after: 2.weeks
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.session_store :cookie_store, key: "_govuk_rails_boilerplate_session", secure: true, expire_after: 2.weeks
+  config.session_store :cookie_store, key: "_support_for_early_career_teachers_session", secure: true, expire_after: 2.weeks
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/spec/cypress/integration/Cookies.feature
+++ b/spec/cypress/integration/Cookies.feature
@@ -52,3 +52,9 @@ Feature: Cookie page
     When I navigate to "cookie" page
     Then "cookie banner" should not exist
     And "cookie consent radio" with value "off" is checked
+
+  Scenario: Footer should have cookies link
+    When I am on "start" page
+    Then "footer" should contain "Cookies"
+    And the page should be accessible
+    And percy should be sent snapshot

--- a/spec/cypress/integration/StartPage.feature
+++ b/spec/cypress/integration/StartPage.feature
@@ -7,3 +7,9 @@ Feature: Start Page
     And the page should be accessible
     And percy should be sent snapshot
 
+  Scenario: Should have cookies link
+    When I am on "start" page
+    Then "footer" should contain "Cookies"
+    And the page should be accessible
+    And percy should be sent snapshot
+

--- a/spec/cypress/integration/StartPage.feature
+++ b/spec/cypress/integration/StartPage.feature
@@ -6,10 +6,3 @@ Feature: Start Page
     Then "phase banner" should contain "feedback"
     And the page should be accessible
     And percy should be sent snapshot
-
-  Scenario: Should have cookies link
-    When I am on "start" page
-    Then "footer" should contain "Cookies"
-    And the page should be accessible
-    And percy should be sent snapshot
-


### PR DESCRIPTION
### Context
[Jira ticket](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-506)

### Changes proposed in this pull request
Adding a link to cookies page in the footer
Renaming the boilerplate session store

### Guidance to review
The acceptance criteria in the Jira ticket was 
- the service footer contains a link ‘Cookies’ (see screenshot below) which links to the cookie page 
- the cookie page is up-to-date and correct

The second point was checked with Michal and confirmed it's up to date. 

<img width="1104" alt="Screenshot 2021-05-27 at 08 42 20" src="https://user-images.githubusercontent.com/69353998/119785913-94d9c080-bec7-11eb-8d93-96fdeee468a3.png">

### Testing
Percy test to check cookies is in the footer

