### PR TITLE
Send invites on user sync

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -74,11 +74,6 @@ private
 
     user = User.find_by(email: email)
 
-    unless user
-      RegisterAndPartnerApi::SyncUsers.perform
-      user = User.find_by(email: email)
-    end
-
     if user.blank?
       user = User.new
       user.errors.add :email, "Enter the email address your school used when they registered your account"

--- a/app/models/invite_email_ect.rb
+++ b/app/models/invite_email_ect.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class InviteEmailEct < TrackedEmail
+  INVITES_SENT_FROM = Date.new(2021, 8, 20).beginning_of_day
+
   def mail_to_send
     UserMailer.ect_welcome_email(user)
+  end
+
+  def send!
+    if Time.zone.now >= INVITES_SENT_FROM
+      super
+    end
   end
 end

--- a/app/services/invite_participants.rb
+++ b/app/services/invite_participants.rb
@@ -8,9 +8,6 @@ class InviteParticipants
     emails.each do |email|
       user = User.find_by(email: email)
       email = create_invite_email_for_user(user)
-
-      # if user is ect and before certain time, don't send
-      # otherwise send
       email.send!
     rescue StandardError
       logger.info "Error emailing user, id: #{user&.id} ... skipping"
@@ -19,9 +16,9 @@ class InviteParticipants
 
   def self.create_invite_email_for_user(user)
     if user.mentor?
-      InviteEmailMentor.create!(user: user)
+      InviteEmailMentor.find_or_create_by!(user: user, sent_at: nil)
     elsif user.early_career_teacher?
-      InviteEmailEct.create!(user: user)
+      InviteEmailEct.find_or_create_by!(user: user, sent_at: nil)
     end
   end
 

--- a/app/services/invite_participants.rb
+++ b/app/services/invite_participants.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 class InviteParticipants
-  def run(emails)
+  def self.run(emails)
     logger.info "Emailing Participants"
 
     user = nil
     emails.each do |email|
       user = User.find_by(email: email)
       email = create_invite_email_for_user(user)
+
+      # if user is ect and before certain time, don't send
+      # otherwise send
       email.send!
     rescue StandardError
       logger.info "Error emailing user, id: #{user&.id} ... skipping"
     end
   end
 
-private
-
-  def create_invite_email_for_user(user)
+  def self.create_invite_email_for_user(user)
     if user.mentor?
       InviteEmailMentor.create!(user: user)
     elsif user.early_career_teacher?
@@ -24,7 +25,9 @@ private
     end
   end
 
-  def logger
+  def self.logger
     @logger ||= Rails.logger
   end
+
+  private_class_method :create_invite_email_for_user, :logger
 end

--- a/lib/tasks/invites.rake
+++ b/lib/tasks/invites.rake
@@ -3,6 +3,6 @@
 namespace :invites do
   desc "Send invites"
   task :send_invites, [:emails] => :environment do |_task, args|
-    InviteParticipants.new.run(args.emails.split)
+    InviteParticipants.run(args.emails.split)
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -4,7 +4,7 @@
       "id": "65abf54c-c7c2-490b-9bcd-bbb4e0aab934",
       "type": "user",
       "attributes": {
-        "email": "lead-provider@example.com",
+        "email": "mentor@example.com",
         "full_name": "Lead Provider",
         "user_type": "mentor",
         "core_induction_programme": "ucl"
@@ -17,7 +17,7 @@
         "email": "school-leader@example.com",
         "full_name": "Induction Tutor",
         "user_type": "mentor",
-        "core_induction_programme": "ucl"
+        "core_induction_programme": "none"
       }
     },
     {

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -18,11 +18,54 @@ RSpec.describe TrackedEmail, type: :model do
   describe "sending ect invite" do
     let(:invite_email_ect) { InviteEmailEct.create!(user: create(:user)) }
 
+    context "before cut off date" do
+      before do
+        travel_to InviteEmailEct::INVITES_SENT_FROM - 2.days
+      end
+
+      it "does not send the email" do
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+        expect(invite_email_ect.notify_id).to be_nil
+        expect(invite_email_ect.sent_to).to be_nil
+      end
+    end
+
+    context "on cutoff date" do
+      before do
+        travel_to InviteEmailEct::INVITES_SENT_FROM
+      end
+
+      it "sends the email" do
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_truthy
+        expect(invite_email_ect.notify_id).to eq("test_id")
+        expect(invite_email_ect.sent_to).to eq(invite_email_ect.user.email)
+      end
+    end
+
+    context "after cutoff date" do
+      before do
+        travel_to InviteEmailEct::INVITES_SENT_FROM + 2.days
+      end
+
+      it "sends the email" do
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_truthy
+        expect(invite_email_ect.notify_id).to eq("test_id")
+        expect(invite_email_ect.sent_to).to eq(invite_email_ect.user.email)
+      end
+    end
+  end
+
+  describe "sending mentor invite" do
+    let(:invite_email_mentor) { InviteEmailMentor.create!(user: create(:user)) }
+
     it "sends the email" do
-      invite_email_ect.send!
-      expect(invite_email_ect.reload.sent?).to be_truthy
-      expect(invite_email_ect.notify_id).to eq("test_id")
-      expect(invite_email_ect.sent_to).to eq(invite_email_ect.user.email)
+      invite_email_mentor.send!
+      expect(invite_email_mentor.reload.sent?).to be_truthy
+      expect(invite_email_mentor.notify_id).to eq("test_id")
+      expect(invite_email_mentor.sent_to).to eq(invite_email_mentor.user.email)
     end
   end
 end

--- a/spec/services/invite_participants_spec.rb
+++ b/spec/services/invite_participants_spec.rb
@@ -8,24 +8,24 @@ RSpec.describe InviteParticipants do
 
   describe "#run" do
     it "creates an ECT email when given ECT user" do
-      expect { InviteParticipants.new.run([ect.email]) }.to change { InviteEmailEct.count }.by(1)
+      expect { InviteParticipants.run([ect.email]) }.to change { InviteEmailEct.count }.by(1)
     end
 
     it "creates an mentor email when given mentor user" do
-      expect { InviteParticipants.new.run([mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      expect { InviteParticipants.run([mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
     end
 
     it "creates an an ect and a mentor email when given an ect and a mentor" do
-      expect { InviteParticipants.new.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
-      expect { InviteParticipants.new.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
+      expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
     end
 
     it "does not stop when it gets an invalid email" do
-      expect { InviteParticipants.new.run(["invalid_email", mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      expect { InviteParticipants.run(["invalid_email", mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
     end
 
     it "does not create any emails when given invalid email" do
-      expect { InviteParticipants.new.run(%w[invalid_email]) }.not_to(change { TrackedEmail.count })
+      expect { InviteParticipants.run(%w[invalid_email]) }.not_to(change { TrackedEmail.count })
     end
   end
 end

--- a/spec/services/invite_participants_spec.rb
+++ b/spec/services/invite_participants_spec.rb
@@ -7,17 +7,49 @@ RSpec.describe InviteParticipants do
   let(:mentor) { create(:user, :mentor) }
 
   describe "#run" do
-    it "creates an ECT email when given ECT user" do
-      expect { InviteParticipants.run([ect.email]) }.to change { InviteEmailEct.count }.by(1)
+    context "when no emails exist previously" do
+      it "creates an ECT email when given ECT user" do
+        expect { InviteParticipants.run([ect.email]) }.to change { InviteEmailEct.count }.by(1)
+      end
+
+      it "creates an mentor email when given mentor user" do
+        expect { InviteParticipants.run([mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      end
+
+      it "creates an an ect and a mentor email when given an ect and a mentor" do
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      end
     end
 
-    it "creates an mentor email when given mentor user" do
-      expect { InviteParticipants.run([mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+    context "when unsent emails exist" do
+      before do
+        InviteEmailEct.create!(user: ect)
+        InviteEmailMentor.create!(user: mentor)
+      end
+
+      it "does not create an email for ect" do
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.not_to(change { InviteEmailEct.count })
+      end
+
+      it "does not create an email for mentor" do
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.not_to(change { InviteEmailMentor.count })
+      end
     end
 
-    it "creates an an ect and a mentor email when given an ect and a mentor" do
-      expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
-      expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+    context "when sent emails exist" do
+      before do
+        InviteEmailEct.create!(user: ect, sent_at: Time.zone.now)
+        InviteEmailMentor.create!(user: mentor, sent_at: Time.zone.now)
+      end
+
+      it "creates an email for ect" do
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
+      end
+
+      it "creates an email for mentor" do
+        expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
+      end
     end
 
     it "does not stop when it gets an invalid email" do

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -40,13 +40,30 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     end
 
     it "updates an existing user that has changed their email address" do
-      create(:user, register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934", email: "lead-provider-1@example.com")
+      create(:user, register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934", email: "mentor-1@example.com")
 
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
       expect(User.count).to eql(3)
-      expect(record.email).to eql("lead-provider@example.com")
+      expect(record.email).to eql("mentor@example.com")
+    end
+
+    it "creates an invite email for new mentors and early career teachers" do
+      allow(InviteParticipants).to receive(:run)
+      described_class.perform
+
+      expect(InviteParticipants).to have_received(:run).with(["mentor@example.com"])
+      expect(InviteParticipants).to have_received(:run).with(["school-leader@example.com"])
+      expect(InviteParticipants).to have_received(:run).with(["rp-ect-ambition@example.com"])
+    end
+
+    it "does not create an invite email for old mentors and early career teachers" do
+      described_class.perform
+
+      allow(InviteParticipants).to receive(:run)
+      described_class.perform
+      expect(InviteParticipants).not_to have_received(:run)
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-490

## Code review

### Is there anything weird that code reviewer should know?
Commit by commit should be pretty straightforward.

I put the logic for whether we want to create an email or not in the sync service. I guess it could live in an after create hook on a user, but at that time we might not yet know whether the user is a mentor or an ect.

I put the logic for whether to send an email or not in the email model.

When we get ECTs, we will create invite emails for them, but we won't send them. At some point we will probably need a job for sending unsent emails.

I added email sending for mentors too, because we want it, and it was easier to add it here than to split it into its own PR. 

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. You can't really. If you want to check that mentors receive an email, we would need to add a mentor that is whitelisted on our notify instance to R&P dev environment, wait 5 minutes for user sync to happen, and then the mentor email should be sent. 
