### PR TITLE
Restrict mentor materials to just mentors with right cip and admins

### DIFF
--- a/app/models/mentor_material.rb
+++ b/app/models/mentor_material.rb
@@ -13,4 +13,16 @@ class MentorMaterial < ApplicationRecord
   def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
   end
+
+  def get_core_induction_programme
+    if course_lesson.present?
+      course_lesson.course_year.core_induction_programme
+    elsif course_module.present?
+      course_module.course_year.core_induction_programme
+    elsif course_year.present?
+      course_year.core_induction_programme
+    else
+      core_induction_programme
+    end
+  end
 end

--- a/app/policies/core_induction_programme_policy.rb
+++ b/app/policies/core_induction_programme_policy.rb
@@ -25,12 +25,12 @@ class CoreInductionProgrammePolicy < ApplicationPolicy
   def update?
     admin_only
   end
-end
 
 private
 
-def has_access_to_cip?(user, cip)
-  return true if admin_only
+  def has_access_to_cip?(user, cip)
+    return true if admin_only
 
-  user && (user.core_induction_programme == cip)
+    user && (user.core_induction_programme == cip)
+  end
 end

--- a/app/policies/mentor_material_policy.rb
+++ b/app/policies/mentor_material_policy.rb
@@ -1,32 +1,9 @@
 # frozen_string_literal: true
 
-class MentorMaterialPolicy < ApplicationPolicy
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
-
-  def index?
-    true
-  end
-
+class MentorMaterialPolicy < CoreInductionProgrammePolicy
   def show?
-    true
-  end
+    return false unless has_access_to_cip?(@user, @record.get_core_induction_programme)
 
-  def edit?
-    admin_only
-  end
-
-  def update?
-    admin_only
-  end
-
-  def new?
-    admin_only
-  end
-
-  def create?
-    admin_only
+    @user&.mentor? || @user&.admin?
   end
 end

--- a/spec/policies/mentor_material_policy_spec.rb
+++ b/spec/policies/mentor_material_policy_spec.rb
@@ -8,24 +8,46 @@ RSpec.describe MentorMaterialPolicy, type: :policy do
 
   context "as admin" do
     let(:user) { create(:user, :admin) }
-    it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_edit_and_update_actions }
     it { is_expected.to permit_new_and_create_actions }
   end
 
   context "as a user" do
     let(:user) { create(:user) }
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:index) }
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_new_and_create_actions }
   end
 
   context "as a visitor" do
     let(:user) { nil }
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:index) }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
+  end
+
+  context "as a mentor with the right CIP" do
+    let(:user) { create(:user, :mentor) }
+
+    before do
+      user.mentor_profile.update!(core_induction_programme: mentor_material.get_core_induction_programme)
+    end
+
     it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_action(:index) }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_new_and_create_actions }
+  end
+
+  context "as a mentor with the wrong CIP" do
+    let(:user) { create(:user, :mentor) }
+
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:index) }
     it { is_expected.to forbid_edit_and_update_actions }
     it { is_expected.to forbid_new_and_create_actions }
   end

--- a/spec/requests/core_induction_programme/mentor_material_spec.rb
+++ b/spec/requests/core_induction_programme/mentor_material_spec.rb
@@ -65,27 +65,25 @@ RSpec.describe "Mentor materials", type: :request do
     end
 
     describe "GET /mentor-materials" do
-      it "renders index template" do
-        get "/mentor-materials"
-        expect(response).to render_template(:index)
+      it "raises an error" do
+        expect { get "/mentor-materials" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     describe "GET /mentor-materials/:id" do
-      it "renders the mentor materials show page" do
-        get "/mentor-materials/#{mentor_material.id}"
-        expect(response).to render_template(:show)
+      it "raises an error" do
+        expect { get "/mentor-materials/#{mentor_material.id}" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     describe "GET /mentor-materials/:id/edit" do
-      it "raises an error when trying to access edit page" do
+      it "raises an error" do
         expect { get "#{mentor_material_path}/edit" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
     describe "PUT /mentor-materials/:id" do
-      it "redirects to the sign in page" do
+      it "raises an error" do
         expect { put mentor_material_path, params: { commit: "Save", content: mentor_material.content } }.to raise_error Pundit::NotAuthorizedError
       end
     end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-516

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as admin.
3. Get a link of ambition mentor material.
4. Login as `ambition-institute-mentor@example.com` - you should be able to see the material when you go to that link.
5. Login as `ucl-mentor@example.com` - you should not be able to see that material.
6. Login as `ambition-institute-early-career-teacher@example.com` - you should not be able to see that material. 
