### PR TITLE
Display hard-coded text if year has no modules

### DIFF
--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -23,18 +23,44 @@
       </div>
     <% end %>
 
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_year.content_to_html.html_safe %>
-    </div>
+    <% if @course_year.course_modules.empty? %>
 
-    <h2 class="govuk-heading-l">Autumn term</h2>
-    <%= render "module_list", locals = { course_modules: @course_year.autumn_modules_with_progress(current_user) } %>
+      <% if current_user&.early_career_teacher? %>
+        <p>
+          The second year offers you the chance to focus on developing your skills in specific areas within the modules.
+        </p>
+        <p>
+          It also allows you to catch up on anything you might have missed in the first year.
+        </p>
+        <p>
+          We’ll give you more details here about how the second year works closer to the time.
+        </p>
+      <% else %>
+        <p>
+          The second year offers the ECT the chance to focus on developing their skills in specific areas within the modules.
+        </p>
+        <p>
+          It also allows them to catch up on anything they might have missed in the first year.
+        </p>
+        <p>
+          We’ll give you more details here about how the second year works closer to the time.
+        </p>
+      <% end %>
 
-    <h2 class="govuk-heading-l">Spring term</h2>
-    <%= render "module_list", locals = { course_modules: @course_year.spring_modules_with_progress(current_user) } %>
+    <% else %>
+      <div class="gem-c-govspeak govuk-govspeak ">
+        <%= @course_year.content_to_html.html_safe %>
+      </div>
 
-    <h2 class="govuk-heading-l">Summer term</h2>
-    <%= render "module_list", locals = { course_modules: @course_year.summer_modules_with_progress(current_user) } %>
+      <h2 class="govuk-heading-l">Autumn term</h2>
+      <%= render "module_list", locals = { course_modules: @course_year.autumn_modules_with_progress(current_user) } %>
+
+      <h2 class="govuk-heading-l">Spring term</h2>
+      <%= render "module_list", locals = { course_modules: @course_year.spring_modules_with_progress(current_user) } %>
+
+      <h2 class="govuk-heading-l">Summer term</h2>
+      <%= render "module_list", locals = { course_modules: @course_year.summer_modules_with_progress(current_user) } %>
+    <% end %>
 
   </div>
 </div>

--- a/spec/cypress/integration/CipYears.feature
+++ b/spec/cypress/integration/CipYears.feature
@@ -21,7 +21,7 @@ Feature: Core Induction Programme years
 
     When I click on "button" containing "Save changes"
     Then "page body" should contain "Your changes have been saved"
-    Then "page body" should contain "New test content"
+    Then "page body" should contain "New test title"
     And the page should be accessible
 
   Scenario: ECTs can view but not edit years

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe "Core Induction Programme Year", type: :request do
         create_cip
         put course_year_path, params: { commit: "Save changes", course_year: { content: "Adding new content" } }
         expect(response).to redirect_to(year_path(course_year))
-        get year_path(course_year)
-        expect(response.body).to include("Adding new content")
+        expect(course_year.reload.content).to include("Adding new content")
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-495

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as `ambition-institute-mentor@example.com`
3. Navigate to year 2 of CIP content, check it looks like what the ticket says
4. Logout, login as `ambition-institute-early-career-teacher@example.com`
5. Navigate to year 2 of CIP content, check it looks like what the ticket says
