### PR TITLE
Add teacher standards

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,6 +20,8 @@ KEY=$(
         grep --invert-match --fixed-strings 'yarn.lock' |
         grep --invert-match --fixed-strings 'Gemfile' |
         grep --invert-match --fixed-strings 'Gemfile.lock' |
+        grep --invert-match --fixed-strings 'db/seeds/cip_seed.rb' |
+        grep --invert-match --fixed-strings 'db/seeds/cip_seed_dump.rb' |
         xargs ls -d 2> /dev/null |
         xargs cat |
         perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'
@@ -28,6 +30,7 @@ KEY=$(
 if [ "$KEY" != "" ]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
     echo "Please check your code and remove API keys."
+    echo "$KEY"
     exit 1
 fi
 

--- a/app/components/govspeak_component.html.erb
+++ b/app/components/govspeak_component.html.erb
@@ -1,0 +1,3 @@
+<div class="gem-c-govspeak govuk-govspeak">
+  <%= @content.html_safe %>
+</div>

--- a/app/components/govspeak_component.rb
+++ b/app/components/govspeak_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GovspeakComponent < ViewComponent::Base
+  def initialize(content:)
+    @content = Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
+  end
+end

--- a/app/controllers/core_induction_programmes/lesson_parts_controller.rb
+++ b/app/controllers/core_induction_programmes/lesson_parts_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgrammes::LessonPartsController < ApplicationController
   include Pundit
-  include GovspeakHelper
   include CipBreadcrumbHelper
 
   after_action :verify_authorized

--- a/app/controllers/core_induction_programmes/lessons_controller.rb
+++ b/app/controllers/core_induction_programmes/lessons_controller.rb
@@ -62,7 +62,15 @@ private
 
   def course_lesson_params
     params.require(:course_lesson).permit(
-      :title, :mentor_title, :ect_summary, :mentor_summary, :completion_time_in_minutes, :course_module_id, :new_position, :ect_teacher_standards, :mentor_teacher_standards
+      :title,
+      :mentor_title,
+      :ect_teacher_standards,
+      :mentor_teacher_standards,
+      :ect_summary,
+      :mentor_summary,
+      :completion_time_in_minutes,
+      :course_module_id,
+      :new_position,
     )
   end
 end

--- a/app/controllers/core_induction_programmes/lessons_controller.rb
+++ b/app/controllers/core_induction_programmes/lessons_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgrammes::LessonsController < ApplicationController
   include Pundit
-  include GovspeakHelper
   include CipBreadcrumbHelper
 
   after_action :verify_authorized

--- a/app/controllers/core_induction_programmes/lessons_controller.rb
+++ b/app/controllers/core_induction_programmes/lessons_controller.rb
@@ -62,6 +62,8 @@ private
   end
 
   def course_lesson_params
-    params.require(:course_lesson).permit(:title, :mentor_title, :ect_summary, :mentor_summary, :completion_time_in_minutes, :course_module_id, :new_position)
+    params.require(:course_lesson).permit(
+      :title, :mentor_title, :ect_summary, :mentor_summary, :completion_time_in_minutes, :course_module_id, :new_position, :ect_teacher_standards, :mentor_teacher_standards
+    )
   end
 end

--- a/app/controllers/core_induction_programmes/modules_controller.rb
+++ b/app/controllers/core_induction_programmes/modules_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgrammes::ModulesController < ApplicationController
   include Pundit
-  include GovspeakHelper
   include CipBreadcrumbHelper
 
   after_action :verify_authorized

--- a/app/controllers/core_induction_programmes/years_controller.rb
+++ b/app/controllers/core_induction_programmes/years_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgrammes::YearsController < ApplicationController
   include Pundit
-  include GovspeakHelper
   include CipBreadcrumbHelper
 
   after_action :verify_authorized

--- a/app/controllers/govspeak_test_controller.rb
+++ b/app/controllers/govspeak_test_controller.rb
@@ -3,15 +3,12 @@
 require "govspeak"
 
 class GovspeakTestController < ApplicationController
-  include GovspeakHelper
   def show
-    @content = content_to_html("")
     @preview_string = ""
   end
 
   def preview
     @preview_string = params[:preview_string]
-    @content = content_to_html(@preview_string)
     render :show
   end
 end

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module GovspeakHelper
-  def content_to_html(page)
-    Govspeak::Document.new(page, options: { allow_extra_quotes: true }).to_html
-  end
-end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -46,14 +46,6 @@ class CourseLesson < ApplicationRecord
     end
   end
 
-  def mentor_summary_to_html
-    Govspeak::Document.new(mentor_summary, options: { allow_extra_quotes: true }).to_html
-  end
-
-  def ect_summary_to_html
-    Govspeak::Document.new(ect_summary, options: { allow_extra_quotes: true }).to_html
-  end
-
   def module_and_lesson
     "#{course_module.title}: #{title}"
   end
@@ -62,10 +54,6 @@ class CourseLesson < ApplicationRecord
     return title if mentor_title.blank?
 
     user.mentor? ? mentor_title : title
-  end
-
-  def teacher_standards_to_html_for(user)
-    Govspeak::Document.new(teacher_standards_for(user), options: { allow_extra_quotes: true }).to_html
   end
 
   def teacher_standards_for(user)

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -64,6 +64,16 @@ class CourseLesson < ApplicationRecord
     user.mentor? ? mentor_title : title
   end
 
+  def teacher_standards_to_html_for(user)
+    Govspeak::Document.new(teacher_standards_for(user), options: { allow_extra_quotes: true }).to_html
+  end
+
+  def teacher_standards_for(user)
+    return ect_teacher_standards if mentor_teacher_standards.blank?
+
+    user.mentor? ? mentor_teacher_standards : ect_teacher_standards
+  end
+
 private
 
   def update_to_new_position

--- a/app/models/course_lesson_part.rb
+++ b/app/models/course_lesson_part.rb
@@ -8,8 +8,4 @@ class CourseLessonPart < ApplicationRecord
 
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
   validates :content, presence: { message: "Enter content" }, length: { maximum: 100_000 }
-
-  def content_to_html
-    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
-  end
 end

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -33,14 +33,6 @@ class CourseModule < ApplicationRecord
 
   enum term: terms
 
-  def mentor_summary_to_html
-    Govspeak::Document.new(mentor_summary, options: { allow_extra_quotes: true }).to_html
-  end
-
-  def ect_summary_to_html
-    Govspeak::Document.new(ect_summary, options: { allow_extra_quotes: true }).to_html
-  end
-
   def lessons_with_progress(user)
     ect_profile = user&.early_career_teacher_profile
     return course_lessons unless ect_profile

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -13,10 +13,6 @@ class CourseYear < ApplicationRecord
   validates :mentor_title, length: { maximum: 255 }
   validates :content, length: { maximum: 100_000 }
 
-  def content_to_html
-    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
-  end
-
   def course_modules_in_order(modules_to_order = course_modules)
     preloaded_modules = modules_to_order.includes(:previous_module, :next_module)
     elements_in_order(elements: preloaded_modules, get_previous_element: :previous_module)

--- a/app/models/mentor_material.rb
+++ b/app/models/mentor_material.rb
@@ -10,10 +10,6 @@ class MentorMaterial < ApplicationRecord
   validates :title, presence: { message: "Enter a title" }, length: { maximum: 255 }
   validates :content, presence: { message: "Enter content" }, length: { maximum: 2_000_000 }
 
-  def content_to_html
-    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
-  end
-
   def get_core_induction_programme
     if course_lesson.present?
       course_lesson.course_year.core_induction_programme

--- a/app/views/core_induction_programmes/lesson_parts/_lesson_part_content.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/_lesson_part_content.html.erb
@@ -19,6 +19,4 @@
 </ul>
 
 <h2 class="govuk-heading-l"> <%= @course_lesson_part.title %></h2>
-<div class="gem-c-govspeak govuk-govspeak">
-  <%= @course_lesson_part.content_to_html.html_safe %>
-</div>
+<%= render GovspeakComponent.new(content: @course_lesson_part.content) %>

--- a/app/views/core_induction_programmes/lesson_parts/edit.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/edit.html.erb
@@ -12,8 +12,6 @@
         <%= f.govuk_submit "Save changes" %>
       </div>
     <% end %>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_lesson_part.content_to_html.html_safe %>
-    </div>
+    <%= render GovspeakComponent.new(content: @course_lesson_part.content) %>
   </div>
 </div>

--- a/app/views/core_induction_programmes/lesson_parts/show_split.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show_split.html.erb
@@ -56,16 +56,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l"><%= @split_lesson_part_form.title %></h2>
-      <div class="gem-c-govspeak govuk-govspeak ">
-        <%= content_to_html(@split_lesson_part_form.content).html_safe %>
-      </div>
+      <%= render GovspeakComponent.new(content: @split_lesson_part_form.content) %>
     </div>
 
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-l"><%= @split_lesson_part_form.new_title %></h2>
-      <div class="gem-c-govspeak govuk-govspeak ">
-        <%= content_to_html(@split_lesson_part_form.new_content).html_safe %>
-      </div>
+      <%= render GovspeakComponent.new(content: @split_lesson_part_form.new_content) %>
     </div>
   </div>
 </div>

--- a/app/views/core_induction_programmes/lessons/_course_lesson_fields.html.erb
+++ b/app/views/core_induction_programmes/lessons/_course_lesson_fields.html.erb
@@ -27,4 +27,14 @@
       label: { text: 'Mentor summary' },
       rows: 10) %>
 
+<%= f.govuk_text_area(
+      :ect_teacher_standards,
+      label: { text: 'ECT Teacher Standards' },
+      rows: 10) %>
+
+<%= f.govuk_text_area(
+      :mentor_teacher_standards,
+      label: { text: 'Mentor Teacher Standards' },
+      rows: 10) %>
+
 <%= f.govuk_submit t(f.object.persisted? ? :update : :create, scope: [:helpers, :submit, :course_lesson]) %>

--- a/app/views/core_induction_programmes/mentor_materials/edit.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/edit.html.erb
@@ -5,8 +5,7 @@
       <%= render "mentor_material_fields", locals = { f:f } %>
       <%= f.govuk_submit "See preview" %>
     <% end %>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @mentor_material.content_to_html.html_safe %>
-    </div>
+
+    <%= render GovspeakComponent.new(content: @mentor_material.content) %>
   </div>
 </div>

--- a/app/views/core_induction_programmes/mentor_materials/show.html.erb
+++ b/app/views/core_induction_programmes/mentor_materials/show.html.erb
@@ -4,8 +4,7 @@
       <%= govuk_link_to "Edit mentor material", edit_mentor_material_path(@mentor_material), button: true %>
     <% end %>
     <h1 class="govuk-heading-xl"><%= @mentor_material.title %></h1>
-    <div class="gem-c-govspeak govuk-govspeak">
-      <%= @mentor_material.content_to_html.html_safe %>
-    </div>
+
+    <%= render GovspeakComponent.new(content: @mentor_material.content) %>
   </div>
 </div>

--- a/app/views/core_induction_programmes/modules/edit.html.erb
+++ b/app/views/core_induction_programmes/modules/edit.html.erb
@@ -6,14 +6,11 @@
       <%= render "course_module_fields", locals = { f:f } %>
       <%= f.govuk_submit "See preview" %>
     <% end %>
+
     <h2 class="govuk-heading-l">ECT summary:</h2>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_module.ect_summary_to_html.html_safe %>
-    </div>
+    <%= render GovspeakComponent.new(content: @course_module.ect_summary) %>
 
     <h2 class="govuk-heading-l">Mentor summary:</h2>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_module.mentor_summary_to_html.html_safe %>
-    </div>
+    <%= render GovspeakComponent.new(content: @course_module.mentor_summary) %>
   </div>
 </div>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -34,9 +34,9 @@
           <% if lesson.teacher_standards_for(current_user).presence %>
             <details class="govuk-details  govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-module="govuk-details">
               <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">
-                View which teachers' standards this topic relates to
-              </span>
+                <span class="govuk-details__summary-text">
+                  View which teachers' standards this topic relates to
+                </span>
               </summary>
               <div class="govuk-details__text">
                 <%= render GovspeakComponent.new(content: lesson.teacher_standards_for(current_user)) %>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -7,18 +7,17 @@
     <h1 class="govuk-heading-l"> <%= @course_module.term_and_title %></h1>
 
     <% if current_user&.admin? %>
+
       <% if @course_module.ect_summary %>
         <h2 class="govuk-heading-m">ECT summary:</h2>
-        <div class="gem-c-govspeak govuk-govspeak ">
-          <%= @course_module.ect_summary_to_html.html_safe %>
-        </div>
+        <%= render GovspeakComponent.new(content: @course_module.ect_summary) %>
       <% end %>
+
       <% if @course_module.mentor_summary %>
         <h2 class="govuk-heading-m">Mentor summary:</h2>
-        <div class="gem-c-govspeak govuk-govspeak ">
-          <%= @course_module.mentor_summary_to_html.html_safe %>
-        </div>
+        <%= render GovspeakComponent.new(content: @course_module.mentor_summary) %>
       <% end %>
+
     <% end %>
 
     <ul class="app-task-list__items">
@@ -40,9 +39,7 @@
               </span>
               </summary>
               <div class="govuk-details__text">
-                <div class="gem-c-govspeak govuk-govspeak">
-                  <%= lesson.teacher_standards_to_html_for(current_user).html_safe %>
-                </div>
+                <%= render GovspeakComponent.new(content: lesson.teacher_standards_for(current_user)) %>
               </div>
             </details>
           <% end %>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -31,7 +31,7 @@
             <% end %>
           </h2>
 
-          <% if lesson.teacher_standards_for(current_user) %>
+          <% if lesson.teacher_standards_for(current_user).presence %>
             <details class="govuk-details  govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-module="govuk-details">
               <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
@@ -47,16 +47,16 @@
           <% if current_user&.admin? %>
             <% if lesson.ect_summary %>
               <h3 class="govuk-heading-s">ECT summary:</h3>
-              <p class="govuk-body"><%= lesson.ect_summary.presence || "No summary available" %></p>
+              <%= render GovspeakComponent.new(content: lesson.ect_summary) %>
             <% end %>
             <% if lesson.mentor_summary %>
               <h3 class="govuk-heading-s">Mentor summary:</h3>
-              <p class="govuk-body"><%= lesson.mentor_summary.presence || "No summary available" %></p>
+              <%= render GovspeakComponent.new(content: lesson.mentor_summary) %>
             <% end %>
           <% elsif current_user.mentor? %>
-            <p class="govuk-body"><%= lesson.mentor_summary.presence %></p>
+            <%= render GovspeakComponent.new(content: lesson.mentor_summary) %>
           <% else %>
-            <p class="govuk-body"><%= lesson.ect_summary.presence %></p>
+            <%= render GovspeakComponent.new(content: lesson.ect_summary) %>
           <% end %>
 
           <% if lesson.course_lesson_parts.any? %>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -32,6 +32,21 @@
             <% end %>
           </h2>
 
+          <% if lesson.teacher_standards_for(current_user) %>
+            <details class="govuk-details  govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                View which teachers' standards this topic relates to
+              </span>
+              </summary>
+              <div class="govuk-details__text">
+                <div class="gem-c-govspeak govuk-govspeak">
+                  <%= lesson.teacher_standards_to_html_for(current_user).html_safe %>
+                </div>
+              </div>
+            </details>
+          <% end %>
+
           <% if current_user&.admin? %>
             <% if lesson.ect_summary %>
               <h3 class="govuk-heading-s">ECT summary:</h3>

--- a/app/views/core_induction_programmes/show.html.erb
+++ b/app/views/core_induction_programmes/show.html.erb
@@ -16,9 +16,8 @@
         <% if policy(course_year).edit? %>
           <%= govuk_link_to "Edit year content", edit_year_path(course_year), button: true %>
         <% end %>
-        <div class="gem-c-govspeak govuk-govspeak ">
-          <%= course_year.content_to_html.html_safe %>
-        </div>
+
+        <%= render GovspeakComponent.new(content: course_year.content) %>
 
         <h3 class="govuk-heading-l">Autumn term</h3>
         <%= render "module_list", locals = { course_modules: course_year.autumn_modules_with_progress(current_user) } %>

--- a/app/views/core_induction_programmes/years/_module_list.html.erb
+++ b/app/views/core_induction_programmes/years/_module_list.html.erb
@@ -6,26 +6,26 @@
           <%= govuk_link_to(course_module.title, module_path(course_module)) %>
         </h3>
 
-        <div class="gem-c-govspeak govuk-govspeak">
           <% if current_user.admin? %>
             <h4 class="govuk-heading-s">Mentor summary</h4>
             <% if course_module.mentor_summary.present? %>
-              <%= course_module.mentor_summary_to_html.html_safe %>
-            <% else %>
+              <%= render GovspeakComponent.new(content: course_module.mentor_summary) %>
+           <% else %>
               <p>No mentor summary</p>
             <% end %>
+
             <h4 class="govuk-heading-s">ECT summary</h4>
             <% if course_module.ect_summary.present? %>
-              <%= course_module.ect_summary_to_html.html_safe %>
+              <%= render GovspeakComponent.new(content: course_module.ect_summary) %>
             <% else %>
               <p>No ECT summary</p>
             <% end %>
+
           <% elsif current_user.mentor? %>
-            <%= course_module.mentor_summary_to_html.html_safe %>
+            <%= render GovspeakComponent.new(content: course_module.mentor_summary) %>
           <% else %>
-            <%= course_module.ect_summary_to_html.html_safe %>
+            <%= render GovspeakComponent.new(content: course_module.ect_summary) %>
           <% end %>
-        </div>
 
         <% if current_user.early_career_teacher? %>
           <div class="app-task-list__section">

--- a/app/views/core_induction_programmes/years/edit.html.erb
+++ b/app/views/core_induction_programmes/years/edit.html.erb
@@ -12,8 +12,7 @@
         <%= f.govuk_submit "Save changes" %>
       </div>
     <% end %>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_year.content_to_html.html_safe %>
-    </div>
+
+    <%= render GovspeakComponent.new(content: @course_year.content) %>
   </div>
 </div>

--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -48,9 +48,8 @@
       <% end %>
 
     <% else %>
-      <div class="gem-c-govspeak govuk-govspeak ">
-        <%= @course_year.content_to_html.html_safe %>
-      </div>
+
+      <%= render GovspeakComponent.new(content: @course_year.content) %>
 
       <h2 class="govuk-heading-l">Autumn term</h2>
       <%= render "module_list", locals = { course_modules: @course_year.autumn_modules_with_progress(current_user) } %>
@@ -60,7 +59,7 @@
 
       <h2 class="govuk-heading-l">Summer term</h2>
       <%= render "module_list", locals = { course_modules: @course_year.summer_modules_with_progress(current_user) } %>
-    <% end %>
 
+    <% end %>
   </div>
 </div>

--- a/app/views/govspeak_test/show.html.erb
+++ b/app/views/govspeak_test/show.html.erb
@@ -5,8 +5,7 @@
       <%= f.govuk_text_area :preview_string, label: { text: "Markdown string to preview" }, rows: 10, value: @preview_string %>
       <%= f.govuk_submit "See preview" %>
     <% end %>
-    <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @content.html_safe %>
-    </div>
+
+    <%= render GovspeakComponent.new(content: @preview_string) %>
   </div>
 </div>

--- a/app/webpacker/vendor_styles/govspeak/helpers/_markdown-typography.scss
+++ b/app/webpacker/vendor_styles/govspeak/helpers/_markdown-typography.scss
@@ -5,8 +5,11 @@
 
   $gutter-two-thirds: $govuk-gutter - ($govuk-gutter / 3);
 
+  ul {
+    @include govuk-font($size: 19);
+  }
+
   ol,
-  ul,
   p {
     @include govuk-font($size: 19);
     margin-top: $govuk-gutter-half;

--- a/db/migrate/20210607151925_add_teacher_standards_to_lessons.rb
+++ b/db/migrate/20210607151925_add_teacher_standards_to_lessons.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddTeacherStandardsToLessons < ActiveRecord::Migration[6.1]
+  def change
+    change_table :course_lessons, bulk: true do |t|
+      t.string :ect_teacher_standards, null: true
+      t.string :mentor_teacher_standards, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_103110) do
+ActiveRecord::Schema.define(version: 2021_06_07_151925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 2021_06_04_103110) do
     t.text "mentor_summary"
     t.integer "position"
     t.string "mentor_title"
+    t.string "ect_teacher_standards"
+    t.string "mentor_teacher_standards"
     t.index ["course_module_id"], name: "index_course_lessons_on_course_module_id"
     t.index ["previous_lesson_id"], name: "index_course_lessons_on_previous_lesson_id"
   end

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -84,4 +84,29 @@ RSpec.describe CourseLesson, type: :model do
       expect(subject.title_for(user)).to eq "Normal title"
     end
   end
+
+  describe "#teacher_standards_for" do
+    subject { FactoryBot.create(:course_lesson, ect_teacher_standards: "Normal standards", mentor_teacher_standards: "Mentor standards") }
+
+    it "is expected to return normal standards for admins" do
+      user = create(:user, :admin)
+      expect(subject.teacher_standards_for(user)).to eq "Normal standards"
+    end
+
+    it "is expected to return mentor standards for mentors" do
+      user = create(:user, :mentor)
+      expect(subject.teacher_standards_for(user)).to eq "Mentor standards"
+    end
+
+    it "is expected to return normal standards for mentors when no mentor standards" do
+      lesson = create(:course_lesson, ect_teacher_standards: "Normal standards")
+      user = create(:user, :mentor)
+      expect(lesson.teacher_standards_for(user)).to eq "Normal standards"
+    end
+
+    it "is expected to return normal standards for ECTs" do
+      user = create(:user, :early_career_teacher)
+      expect(subject.teacher_standards_for(user)).to eq "Normal standards"
+    end
+  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-504

## Code review

### Is there anything weird that code reviewer should know?
Going commit by commit should be easiest.

I got annoyed by how often and how differently we handled govspeak content, so I made a component for it. And removed all other handling of govspeak content. 

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Sign in as admin
3. Go to any CIP lesson, click on "Edit lesson" button
4. Fill the ect teacher standards field, and the mentor teacher standards fiend (if you want)
5. Log out and log in as the ect / mentor that should be able to see that lesson
6. There should be an accordion with TS on the course module page (where you can see a list of course lessons)
