### PR TITLE
Add top section break in ECTs progress

### DIFF
--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -60,18 +60,21 @@
           <% end %>
 
           <% if lesson.course_lesson_parts.any? %>
-            <div class="app-task-list__section">
 
-               <% if current_user&.early_career_teacher? %>
-                 <%= govuk_link_to "Work through the self-study material#{
+            <% if current_user&.early_career_teacher? %>
+              <hr class="govuk-section-break govuk-section-break--visible" />
+              <div class="app-task-list__section">
+                <%= govuk_link_to "Work through the self-study material#{
                     lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
                   }", lesson_path(lesson) %>
-                 <%= render ProgressLabelComponent.new progress: lesson.progress %>
-               <% else %>
-                  <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
-               <% end %>
+                <%= render ProgressLabelComponent.new progress: lesson.progress %>
+              </div>
+            <% else %>
+              <div class="app-task-list__section">
+                <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
+              </div>
+            <% end %>
 
-            </div>
           <% end %>
         </li>
       <% end.empty? %>

--- a/app/views/core_induction_programmes/years/_module_list.html.erb
+++ b/app/views/core_induction_programmes/years/_module_list.html.erb
@@ -28,11 +28,14 @@
           <% end %>
 
         <% if current_user.early_career_teacher? %>
+          <hr class="govuk-section-break govuk-section-break--visible" />
           <div class="app-task-list__section">
             <span><%= course_module.self_study_lessons.count.humanize.capitalize %> self-study <%= "session".pluralize(course_module.course_lessons.count) %></span>
 
             <%= render ProgressLabelComponent.new progress: course_module.progress %>
           </div>
+        <% else %>
+          <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-3" />
         <% end %>
       </div>
     </li>


### PR DESCRIPTION
## Ticket and context

Ticket: [538](https://dfedigital.atlassian.net/browse/CPDEL-538)

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review
It's in the years overview and weekly lessons overview but it should look roughly like the below

ECT view weekly
<img width="575" alt="Screenshot 2021-06-09 at 12 47 57" src="https://user-images.githubusercontent.com/69353998/121360689-8dd19a00-c92c-11eb-8ffa-0be8a2071e8d.png">

ECT view yearly
![Screenshot 2021-06-09 at 17 30 45](https://user-images.githubusercontent.com/69353998/121393642-76080f00-c948-11eb-9617-216816173fa0.png)

Mentor view weekly
<img width="551" alt="Screenshot 2021-06-09 at 12 48 01" src="https://user-images.githubusercontent.com/69353998/121360415-4fd47600-c92c-11eb-8e28-a92515663291.png">

Mentor view yearly
![Screenshot 2021-06-09 at 17 28 57](https://user-images.githubusercontent.com/69353998/121393422-3a6d4500-c948-11eb-990c-2404193dfd9b.png)

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login in as an ECT `ambition-institute-early-career-teacher@example.com`
3. Check it looks like the ECT image above on yearly and weekly pages
4. Logout
5. Login as a Mentor `ambition-institute-mentor@example.com`
6. It should look like the Mentor image above on yearly and weekly pages

