### PR TITLE
[CPDEL-517] - onboarding emails can be sent automatically to mentors

### DIFF
--- a/app/models/invite_email_mentor.rb
+++ b/app/models/invite_email_mentor.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class InviteEmailMentor < TrackedEmail
+  INVITES_SENT_FROM = Date.new(2021, 6, 30).beginning_of_day
+
   def mail_to_send
     UserMailer.mentor_welcome_email(user)
+  end
+
+  def send!
+    if Time.zone.now >= INVITES_SENT_FROM
+      super
+    end
   end
 end

--- a/spec/services/invite_participants_spec.rb
+++ b/spec/services/invite_participants_spec.rb
@@ -16,8 +16,11 @@ RSpec.describe InviteParticipants do
         expect { InviteParticipants.run([mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
       end
 
-      it "creates an an ect and a mentor email when given an ect and a mentor" do
+      it "creates a ect email when given an ect and a mentor" do
         expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailEct.count }.by(1)
+      end
+
+      it "creates a mentor email when given an ect and a mentor" do
         expect { InviteParticipants.run([ect.email, mentor.email]) }.to change { InviteEmailMentor.count }.by(1)
       end
     end


### PR DESCRIPTION
## Ticket and context

Ticket: [552](https://dfedigital.atlassian.net/browse/CPDEL-552)

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward. It works the same as InviteEmailEct.

We've set the `INVITES_SENT_FROM` date as 30 June, the month has been agreed but not the day so I've put it as far away as possible for now. 

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
You can't.
