### PR TITLE
Fix module progress empty lessons

### DIFF
--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -25,6 +25,8 @@ class CourseLesson < ApplicationRecord
 
   after_commit :update_to_new_position
 
+  scope :with_self_study_materials, -> { includes(:course_lesson_parts).joins(:course_lesson_parts) }
+
   def course_lesson_parts_in_order
     preloaded_parts = course_lesson_parts.includes(:previous_lesson_part, :next_lesson_part)
     elements_in_order(elements: preloaded_parts, get_previous_element: :previous_lesson_part)

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -41,7 +41,7 @@ class CourseModule < ApplicationRecord
   end
 
   def self_study_lessons
-    course_lessons.includes(:course_lesson_parts).joins(:course_lesson_parts)
+    course_lessons.with_self_study_materials
   end
 
   def term_and_title

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -35,7 +35,7 @@ class CourseYear < ApplicationRecord
     ect_profile = user&.early_career_teacher_profile
     return modules_in_order unless ect_profile
 
-    course_lessons = CourseLesson.where(course_module: modules_in_order)
+    course_lessons = CourseLesson.with_self_study_materials.where(course_module: modules_in_order)
     lessons_with_progresses = get_user_lessons_and_progresses(ect_profile, course_lessons)
 
     compute_user_course_module_progress(lessons_with_progresses, modules_in_order)

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -62,14 +62,17 @@
           <% if lesson.course_lesson_parts.any? %>
             <div class="app-task-list__section">
 
-               <% if current_user&.early_career_teacher? %>
-                 <%= govuk_link_to "Work through the self-study material#{
-                    lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
-                  }", lesson_path(lesson) %>
-                 <%= render ProgressLabelComponent.new progress: lesson.progress %>
-               <% else %>
-                  <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
-               <% end %>
+              <% if current_user&.early_career_teacher? %>
+                <%= govuk_link_to "Work through the self-study material#{
+                  lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
+                }", lesson_path(lesson) %>
+
+                <% if lesson.course_lesson_parts.any? %>
+                  <%= render ProgressLabelComponent.new progress: lesson.progress %>
+                <% end %>
+              <% else %>
+                <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
+              <% end %>
 
             </div>
           <% end %>

--- a/app/views/core_induction_programmes/modules/show.html.erb
+++ b/app/views/core_induction_programmes/modules/show.html.erb
@@ -66,10 +66,7 @@
                 <%= govuk_link_to "Work through the self-study material#{
                   lesson.completion_time_in_minutes ? " (#{lesson.completion_time_in_minutes} minutes)" : ""
                 }", lesson_path(lesson) %>
-
-                <% if lesson.course_lesson_parts.any? %>
-                  <%= render ProgressLabelComponent.new progress: lesson.progress %>
-                <% end %>
+                <%= render ProgressLabelComponent.new progress: lesson.progress %>
               <% else %>
                 <%= govuk_link_to "View the teacher's self study materials", lesson_path(lesson) %>
               <% end %>

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe CourseYear, type: :model do
 
       @course_year = FactoryBot.create(:course_year)
       @course_module_one = FactoryBot.create(:course_module, title: "One", course_year: @course_year, term: "summer")
-      @course_lesson_one = FactoryBot.create(:course_lesson, course_module: @course_module_one)
-      @course_lesson_two = FactoryBot.create(:course_lesson, course_module: @course_module_one)
+      @course_lesson_one = FactoryBot.create(:course_lesson, :with_lesson_part, course_module: @course_module_one)
+      @course_lesson_two = FactoryBot.create(:course_lesson, :with_lesson_part, course_module: @course_module_one)
 
       @course_lesson_one_progress = FactoryBot.create(
         :course_lesson_progress, course_lesson: @course_lesson_one, early_career_teacher_profile: @teacher.early_career_teacher_profile
@@ -104,6 +104,16 @@ RSpec.describe CourseYear, type: :model do
     it "returns a progress of complete when all lessons in that module are complete" do
       @course_lesson_one_progress.complete!
       @course_lesson_two_progress.complete!
+
+      module_progress = @course_year.modules_with_progress(@teacher).first
+      expect(module_progress.progress).to eql("complete")
+    end
+
+    it "returns a progress of complete when all lessons with content in that module are complete" do
+      @course_lesson_one_progress.complete!
+      @course_lesson_two_progress.complete!
+
+      FactoryBot.create(:course_lesson, course_module: @course_module_one)
 
       module_progress = @course_year.modules_with_progress(@teacher).first
       expect(module_progress.progress).to eql("complete")


### PR DESCRIPTION
## Ticket and context

No ticket.

I just remembered that with content-less lessons in place we probably should not count those towards progress of a module for the ECT. Cause they can't enter them and set the progress.

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Sign in as ucl user. Go to a module 1, with some content-less lessons.
3. Try completing it - finishing all lessons with content should make the whole module complete.
