### PR TITLE
Cpdel 549 stop fip user email and login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -79,7 +79,7 @@ private
       user.errors.add :email, "Enter the email address your school used when they registered your account"
     end
 
-    if user.is_on_full_induction_programme?
+    if user.is_not_on_core_induction_programme?
       user.errors.add :induction_programme_choice, "Please go to your provider's system to access your training materials"
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -79,6 +79,10 @@ private
       user.errors.add :email, "Enter the email address your school used when they registered your account"
     end
 
+    if user.is_on_full_induction_programme?
+      user.errors.add :induction_programme_choice, "Please go to your provider's system to access your training materials"
+    end
+
     user
   end
 end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class EarlyCareerTeacherProfile < ApplicationRecord
+  enum induction_programme_choice: {
+    core_induction_programme: "core_induction_programme",
+    full_induction_programme: "full_induction_programme",
+    not_yet_known: "not_yet_known",
+  }
+
   belongs_to :user
   belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -4,6 +4,8 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   enum induction_programme_choice: {
     core_induction_programme: "core_induction_programme",
     full_induction_programme: "full_induction_programme",
+    design_our_own: "design_our_own",
+    no_early_career_teachers: "no_early_career_teachers",
     not_yet_known: "not_yet_known",
   }
 

--- a/app/models/invite_email_ect.rb
+++ b/app/models/invite_email_ect.rb
@@ -8,7 +8,7 @@ class InviteEmailEct < TrackedEmail
   end
 
   def send!
-    if Time.zone.now >= INVITES_SENT_FROM
+    if user.is_on_core_induction_programme? && Time.zone.now >= INVITES_SENT_FROM
       super
     end
   end

--- a/app/models/invite_email_mentor.rb
+++ b/app/models/invite_email_mentor.rb
@@ -8,7 +8,7 @@ class InviteEmailMentor < TrackedEmail
   end
 
   def send!
-    if Time.zone.now >= INVITES_SENT_FROM
+    if user.is_on_core_induction_programme? && Time.zone.now >= INVITES_SENT_FROM
       super
     end
   end

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -4,6 +4,8 @@ class MentorProfile < ApplicationRecord
   enum induction_programme_choice: {
     core_induction_programme: "core_induction_programme",
     full_induction_programme: "full_induction_programme",
+    design_our_own: "design_our_own",
+    no_early_career_teachers: "no_early_career_teachers",
     not_yet_known: "not_yet_known",
   }
 

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class MentorProfile < ApplicationRecord
+  enum induction_programme_choice: {
+    core_induction_programme: "core_induction_programme",
+    full_induction_programme: "full_induction_programme",
+    not_yet_known: "not_yet_known",
+  }
+
   belongs_to :user
   belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,13 +37,13 @@ class User < ApplicationRecord
   end
 
   def is_on_full_induction_programme?
-    early_career_teacher_profile&.induction_programme_choice == "full_induction_programme" ||
-      mentor_profile&.induction_programme_choice == "full_induction_programme"
+    early_career_teacher_profile&.full_induction_programme? ||
+      mentor_profile&.full_induction_programme?
   end
 
   def is_on_core_induction_programme?
-    early_career_teacher_profile&.induction_programme_choice == "core_induction_programme" ||
-      mentor_profile&.induction_programme_choice == "core_induction_programme"
+    early_career_teacher_profile&.core_induction_programme? ||
+      mentor_profile&.core_induction_programme?
   end
 
   def course_years

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,10 +37,7 @@ class User < ApplicationRecord
   end
 
   def is_not_on_core_induction_programme?
-    is_on_full_induction_programme? ||
-      is_on_designed_programme? ||
-      programme_has_no_early_career_teachers? ||
-      programme_not_yet_known?
+    !is_on_core_induction_programme? && (mentor? || early_career_teacher?)
   end
 
   def is_on_core_induction_programme?
@@ -54,26 +51,6 @@ class User < ApplicationRecord
 
   def name
     preferred_name&.presence || full_name
-  end
-
-  def is_on_full_induction_programme?
-    early_career_teacher_profile&.full_induction_programme? ||
-      mentor_profile&.full_induction_programme?
-  end
-
-  def is_on_designed_programme?
-    early_career_teacher_profile&.design_our_own? ||
-      mentor_profile&.design_our_own?
-  end
-
-  def programme_has_no_early_career_teachers?
-    early_career_teacher_profile&.no_early_career_teachers? ||
-      mentor_profile&.no_early_career_teachers?
-  end
-
-  def programme_not_yet_known?
-    early_career_teacher_profile&.not_yet_known? ||
-      mentor_profile&.not_yet_known?
   end
 
   def user_description

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,16 @@ class User < ApplicationRecord
     mentor_profile.core_induction_programme if mentor?
   end
 
+  def is_on_full_induction_programme?
+    early_career_teacher_profile&.induction_programme_choice == "full_induction_programme" ||
+      mentor_profile&.induction_programme_choice == "full_induction_programme"
+  end
+
+  def is_on_core_induction_programme?
+    early_career_teacher_profile&.induction_programme_choice == "core_induction_programme" ||
+      mentor_profile&.induction_programme_choice == "core_induction_programme"
+  end
+
   def course_years
     core_induction_programme&.course_years || []
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,9 +36,11 @@ class User < ApplicationRecord
     mentor_profile.core_induction_programme if mentor?
   end
 
-  def is_on_full_induction_programme?
-    early_career_teacher_profile&.full_induction_programme? ||
-      mentor_profile&.full_induction_programme?
+  def is_not_on_core_induction_programme?
+    is_on_full_induction_programme? ||
+      is_on_designed_programme? ||
+      programme_has_no_early_career_teachers? ||
+      programme_not_yet_known?
   end
 
   def is_on_core_induction_programme?
@@ -52,6 +54,26 @@ class User < ApplicationRecord
 
   def name
     preferred_name&.presence || full_name
+  end
+
+  def is_on_full_induction_programme?
+    early_career_teacher_profile&.full_induction_programme? ||
+      mentor_profile&.full_induction_programme?
+  end
+
+  def is_on_designed_programme?
+    early_career_teacher_profile&.design_our_own? ||
+      mentor_profile&.design_our_own?
+  end
+
+  def programme_has_no_early_career_teachers?
+    early_career_teacher_profile&.no_early_career_teachers? ||
+      mentor_profile&.no_early_career_teachers?
+  end
+
+  def programme_not_yet_known?
+    early_career_teacher_profile&.not_yet_known? ||
+      mentor_profile&.not_yet_known?
   end
 
   def user_description

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -52,6 +52,7 @@ module RegisterAndPartnerApi
         email: user_from_api.attributes[:attributes][:email],
         user_type: user_from_api.attributes[:attributes][:user_type],
         cip: user_from_api.attributes[:attributes][:core_induction_programme],
+        induction_programme_choice: user_from_api.attributes[:attributes][:induction_programme_choice],
       }
     end
 
@@ -71,6 +72,7 @@ module RegisterAndPartnerApi
       user.full_name = attributes[:full_name]
       user.save!
       profile.core_induction_programme = get_core_induction_programme(attributes)
+      profile.induction_programme_choice = attributes[:induction_programme_choice]
       profile.save!
     end
 

--- a/db/migrate/20210614075746_add_induction_programme_choice_to_early_career_teacher_profile.rb
+++ b/db/migrate/20210614075746_add_induction_programme_choice_to_early_career_teacher_profile.rb
@@ -2,6 +2,6 @@
 
 class AddInductionProgrammeChoiceToEarlyCareerTeacherProfile < ActiveRecord::Migration[6.1]
   def change
-    add_column :early_career_teacher_profiles, :induction_programme_choice, :string
+    add_column :early_career_teacher_profiles, :induction_programme_choice, :string, default: "not_yet_known"
   end
 end

--- a/db/migrate/20210614075746_add_induction_programme_choice_to_early_career_teacher_profile.rb
+++ b/db/migrate/20210614075746_add_induction_programme_choice_to_early_career_teacher_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInductionProgrammeChoiceToEarlyCareerTeacherProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_column :early_career_teacher_profiles, :induction_programme_choice, :string
+  end
+end

--- a/db/migrate/20210614075806_add_induction_programme_choice_to_mentor_profile.rb
+++ b/db/migrate/20210614075806_add_induction_programme_choice_to_mentor_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInductionProgrammeChoiceToMentorProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_column :mentor_profiles, :induction_programme_choice, :string
+  end
+end

--- a/db/migrate/20210614075806_add_induction_programme_choice_to_mentor_profile.rb
+++ b/db/migrate/20210614075806_add_induction_programme_choice_to_mentor_profile.rb
@@ -2,6 +2,6 @@
 
 class AddInductionProgrammeChoiceToMentorProfile < ActiveRecord::Migration[6.1]
   def change
-    add_column :mentor_profiles, :induction_programme_choice, :string
+    add_column :mentor_profiles, :induction_programme_choice, :string, default: "not_yet_known"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_075806) do
     t.uuid "cohort_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "induction_programme_choice"
+    t.string "induction_programme_choice", default: "not_yet_known"
     t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
@@ -165,7 +165,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_075806) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "core_induction_programme_id"
     t.uuid "cohort_id"
-    t.string "induction_programme_choice"
+    t.string "induction_programme_choice", default: "not_yet_known"
     t.index ["cohort_id"], name: "index_mentor_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_mentor_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_mentor_profiles_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_151925) do
+ActiveRecord::Schema.define(version: 2021_06_14_075806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_151925) do
     t.uuid "cohort_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "induction_programme_choice"
     t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
@@ -164,6 +165,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_151925) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "core_induction_programme_id"
     t.uuid "cohort_id"
+    t.string "induction_programme_choice"
     t.index ["cohort_id"], name: "index_mentor_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_mentor_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_mentor_profiles_on_user_id"

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -27,11 +27,11 @@ unless Rails.env.production?
     ect_user = User.find_or_create_by!(email: "#{cip_name_for_email}-early-career-teacher@example.com") do |u|
       u.full_name = "#{cip.name} ECT User"
     end
-    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: cip)
+    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: cip, induction_programme_choice: "core_induction_programme")
 
     mentor_user = User.find_or_create_by!(email: "#{cip_name_for_email}-mentor@example.com") do |u|
       u.full_name = "#{cip.name} Mentor User"
     end
-    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: cip)
+    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: cip, induction_programme_choice: "core_induction_programme")
   end
 end

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :early_career_teacher_profile do
     user
     core_induction_programme
+    induction_programme_choice { "core_induction_programme" }
   end
 end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :mentor_profile do
     user
     core_induction_programme
+    induction_programme_choice { "core_induction_programme" }
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -7,7 +7,8 @@
         "email": "mentor@example.com",
         "full_name": "Lead Provider",
         "user_type": "mentor",
-        "core_induction_programme": "ucl"
+        "core_induction_programme": "ucl",
+        "induction_programme_choice": "core_induction_programme"
       }
     },
     {
@@ -17,7 +18,8 @@
         "email": "school-leader@example.com",
         "full_name": "Induction Tutor",
         "user_type": "mentor",
-        "core_induction_programme": "none"
+        "core_induction_programme": "none",
+        "induction_programme_choice": "core_induction_programme"
       }
     },
     {
@@ -27,7 +29,8 @@
         "email": "rp-ect-ambition@example.com",
         "full_name": "Joe Bloggs",
         "user_type": "early_career_teacher",
-        "core_induction_programme": "ambition"
+        "core_induction_programme": "ambition",
+        "induction_programme_choice": "core_induction_programme"
       }
     },
     {
@@ -37,7 +40,19 @@
         "email": "user_type_other@example.com",
         "full_name": "Jane Doe",
         "user_type": "other",
-        "core_induction_programme": "ucl"
+        "core_induction_programme": "ucl",
+        "induction_programme_choice": "core_induction_programme"
+      }
+    },
+    {
+      "id": "d97fbf35-842f-4c12-a191-fcd2d6317e39",
+      "type": "user",
+      "attributes": {
+        "email": "rp-ect-edt@example.com",
+        "full_name": "Steve Austin",
+        "user_type": "early_career_teacher",
+        "core_induction_programme": "edt",
+        "induction_programme_choice": "full_induction_programme"
       }
     }
   ]

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe TrackedEmail, type: :model do
   end
 
   describe "sending ect invite" do
-    let(:invite_email_ect) { InviteEmailEct.create!(user: create(:user)) }
+    let(:ect) { create(:user, :early_career_teacher) }
+    let(:invite_email_ect) { InviteEmailEct.create!(user: ect) }
 
     context "before cut off date" do
       before do
@@ -55,11 +56,18 @@ RSpec.describe TrackedEmail, type: :model do
         expect(invite_email_ect.notify_id).to eq("test_id")
         expect(invite_email_ect.sent_to).to eq(invite_email_ect.user.email)
       end
+
+      it "does not send the email to a full induction programme ect user" do
+        ect.early_career_teacher_profile.update!(induction_programme_choice: "full_induction_programme")
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
     end
   end
 
   describe "sending mentor invite" do
-    let(:invite_email_mentor) { InviteEmailMentor.create!(user: create(:user)) }
+    let(:mentor) { create(:user, :mentor) }
+    let(:invite_email_mentor) { InviteEmailMentor.create!(user: mentor) }
 
     context "before cut off date" do
       before do
@@ -84,6 +92,12 @@ RSpec.describe TrackedEmail, type: :model do
         expect(invite_email_mentor.reload.sent?).to be_truthy
         expect(invite_email_mentor.notify_id).to eq("test_id")
         expect(invite_email_mentor.sent_to).to eq(invite_email_mentor.user.email)
+      end
+
+      it "does not send the email to a full induction programme mentor user" do
+        mentor.mentor_profile.update!(induction_programme_choice: "full_induction_programme")
+        invite_email_mentor.send!
+        expect(invite_email_mentor.reload.sent?).to be_falsey
       end
     end
 

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe TrackedEmail, type: :model do
       end
 
       it "does not send the email to a full induction programme ect user" do
-        ect.early_career_teacher_profile.update!(induction_programme_choice: "full_induction_programme")
+        ect.early_career_teacher_profile.full_induction_programme!
         invite_email_ect.send!
         expect(invite_email_ect.reload.sent?).to be_falsey
       end
@@ -95,7 +95,7 @@ RSpec.describe TrackedEmail, type: :model do
       end
 
       it "does not send the email to a full induction programme mentor user" do
-        mentor.mentor_profile.update!(induction_programme_choice: "full_induction_programme")
+        mentor.mentor_profile.full_induction_programme!
         invite_email_mentor.send!
         expect(invite_email_mentor.reload.sent?).to be_falsey
       end

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe TrackedEmail, type: :model do
         invite_email_ect.send!
         expect(invite_email_ect.reload.sent?).to be_falsey
       end
+
+      it "does not send the email to ect if programme has no ects" do
+        ect.early_career_teacher_profile.no_early_career_teachers!
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to ect if programme is being designed" do
+        ect.early_career_teacher_profile.design_our_own!
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to ect if induction programme is not yet known" do
+        ect.early_career_teacher_profile.not_yet_known!
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
     end
   end
 
@@ -96,6 +114,24 @@ RSpec.describe TrackedEmail, type: :model do
 
       it "does not send the email to a full induction programme mentor user" do
         mentor.mentor_profile.full_induction_programme!
+        invite_email_mentor.send!
+        expect(invite_email_mentor.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to a mentor if programme has no ects" do
+        mentor.mentor_profile.no_early_career_teachers!
+        invite_email_mentor.send!
+        expect(invite_email_mentor.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to mentor if programme is being designed" do
+        mentor.mentor_profile.design_our_own!
+        invite_email_mentor.send!
+        expect(invite_email_mentor.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to mentor if induction programme is not yet known" do
+        mentor.mentor_profile.not_yet_known!
         invite_email_mentor.send!
         expect(invite_email_mentor.reload.sent?).to be_falsey
       end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -46,43 +46,91 @@ RSpec.describe "Users::Sessions", type: :request do
   end
 
   describe "POST /users/sign_in" do
-    context "when email matches an ect" do
-      let(:user) { create(:user, :early_career_teacher) }
+    context "when an early career teacher is trying to log in" do
+      let(:ect) { create(:user, :early_career_teacher) }
 
-      it "redirects to dashboard" do
-        post "/users/sign_in", params: { user: { email: user.email } }
-        expect(response).to redirect_to(dashboard_path)
-        expect(user.reload.last_sign_in_at).not_to be_nil
+      context "when email matches an ect" do
+        it "redirects to dashboard" do
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to redirect_to(dashboard_path)
+          expect(ect.reload.last_sign_in_at).not_to be_nil
+        end
+      end
+
+      context "when a user's induction programme choice is a full induction programme" do
+        it "renders sign_in page" do
+          ect.early_career_teacher_profile.full_induction_programme!
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when a user's induction programme choice has no early career teachers" do
+        it "renders sign_in page" do
+          ect.early_career_teacher_profile.no_early_career_teachers!
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when a user is doing a designed induction programme" do
+        it "renders sign_in page" do
+          ect.early_career_teacher_profile.design_our_own!
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when a user's induction programme choice is not yet known" do
+        it "renders sign_in page" do
+          ect.early_career_teacher_profile.not_yet_known!
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to render_template(:new)
+        end
       end
     end
 
-    context "when a user's induction programme choice is a full induction programme" do
-      let(:user) { create(:user, :early_career_teacher) }
+    context "when a mentor is trying to log in" do
+      let(:mentor) { create(:user, :mentor) }
 
-      it "renders sign_in page" do
-        user.early_career_teacher_profile.full_induction_programme!
-        post "/users/sign_in", params: { user: { email: user.email } }
-        expect(response).to render_template(:new)
+      context "when email matches a mentor" do
+        it "redirects to dashboard" do
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to redirect_to(dashboard_path)
+          expect(mentor.reload.last_sign_in_at).not_to be_nil
+        end
       end
-    end
 
-    context "when email matches a mentor" do
-      let(:user) { create(:user, :mentor) }
-
-      it "redirects to dashboard" do
-        post "/users/sign_in", params: { user: { email: user.email } }
-        expect(response).to redirect_to(dashboard_path)
-        expect(user.reload.last_sign_in_at).not_to be_nil
+      context "when a user's induction programme choice is a full induction programme" do
+        it "renders sign_in page" do
+          mentor.mentor_profile.full_induction_programme!
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to render_template(:new)
+        end
       end
-    end
 
-    context "when a user's induction programme choice is a full induction programme" do
-      let(:user) { create(:user, :mentor) }
+      context "when a user's induction programme choice has no early career teachers" do
+        it "renders sign_in page" do
+          mentor.mentor_profile.no_early_career_teachers!
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to render_template(:new)
+        end
+      end
 
-      it "renders sign_in page" do
-        user.mentor_profile.full_induction_programme!
-        post "/users/sign_in", params: { user: { email: user.email } }
-        expect(response).to render_template(:new)
+      context "when a user is doing a designed induction programme" do
+        it "renders sign_in page" do
+          mentor.mentor_profile.design_our_own!
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when a user's induction programme choice is not yet known" do
+        it "renders sign_in page" do
+          mentor.mentor_profile.not_yet_known!
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to render_template(:new)
+        end
       end
     end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe "Users::Sessions", type: :request do
       end
     end
 
+    context "when a user's induction programme choice is a full induction programme" do
+      let(:user) { create(:user, :early_career_teacher) }
+
+      it "renders sign_in page" do
+        user.early_career_teacher_profile.update!(induction_programme_choice: "full_induction_programme")
+        post "/users/sign_in", params: { user: { email: user.email } }
+        expect(response).to render_template(:new)
+      end
+    end
+
     context "when email matches a mentor" do
       let(:user) { create(:user, :mentor) }
 
@@ -63,6 +73,16 @@ RSpec.describe "Users::Sessions", type: :request do
         post "/users/sign_in", params: { user: { email: user.email } }
         expect(response).to redirect_to(dashboard_path)
         expect(user.reload.last_sign_in_at).not_to be_nil
+      end
+    end
+
+    context "when a user's induction programme choice is a full induction programme" do
+      let(:user) { create(:user, :mentor) }
+
+      it "renders sign_in page" do
+        user.mentor_profile.update!(induction_programme_choice: "full_induction_programme")
+        post "/users/sign_in", params: { user: { email: user.email } }
+        expect(response).to render_template(:new)
       end
     end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Users::Sessions", type: :request do
       let(:user) { create(:user, :early_career_teacher) }
 
       it "renders sign_in page" do
-        user.early_career_teacher_profile.update!(induction_programme_choice: "full_induction_programme")
+        user.early_career_teacher_profile.full_induction_programme!
         post "/users/sign_in", params: { user: { email: user.email } }
         expect(response).to render_template(:new)
       end
@@ -80,7 +80,7 @@ RSpec.describe "Users::Sessions", type: :request do
       let(:user) { create(:user, :mentor) }
 
       it "renders sign_in page" do
-        user.mentor_profile.update!(induction_programme_choice: "full_induction_programme")
+        user.mentor_profile.full_induction_programme!
         post "/users/sign_in", params: { user: { email: user.email } }
         expect(response).to render_template(:new)
       end

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     it "imports all users returned" do
       expect {
         described_class.perform
-      }.to change(User, :count).by(3)
+      }.to change(User, :count).by(4)
     end
 
     it "does not create the users again" do
       expect {
         described_class.perform
         described_class.perform
-      }.to change(User, :count).by(3)
+      }.to change(User, :count).by(4)
     end
 
     it "does not create a user when given a user type of other" do
@@ -22,7 +22,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
 
       record = User.find_by(email: "user_type_other@example.com")
       expect(record.nil?).to be true
-      expect(User.count).to eql(3)
+      expect(User.count).to eql(4)
     end
 
     it "creates users with correct attributes" do
@@ -45,7 +45,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
-      expect(User.count).to eql(3)
+      expect(User.count).to eql(4)
       expect(record.email).to eql("mentor@example.com")
     end
 


### PR DESCRIPTION
## Ticket and context

Ticket: [549](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-549)

## Code review

### Is there anything weird that code reviewer should know?
The addition of induction_programme_choice to has been made in [PR-518](https://github.com/DFE-Digital/early-careers-framework/pull/518) on Register and Partner. 

We only store the induction programme choice for synced users. Do we want to set it default to core for all users?

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Try to login as a cip user, `rp-mentor-ambition@example.com`, you should be able to login.
3. Try to login as a fip user, `rp-ect-ucl@example.com` or `rp-mentor-ucl@example.com and you should see an error page. 


You should see 

<img width="701" alt="Screenshot 2021-06-16 at 10 47 44" src="https://user-images.githubusercontent.com/69353998/122197713-63359300-ce90-11eb-9e37-4631dd3c01c8.png">
