### PR TITLE
Add a nightly job to sync all users

### DIFF
--- a/app/jobs/sync_all_users_job.rb
+++ b/app/jobs/sync_all_users_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SyncAllUsersJob < CronJob
+  self.cron_expression = "0 0 * * *"
+
+  queue_as :sync_users
+
+  def perform
+    Rails.logger.info "Syncing all users with Register and Partner..."
+    RegisterAndPartnerApi::SyncUsers.perform(all: true)
+  end
+end

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -15,11 +15,15 @@ module RegisterAndPartnerApi
       none: "none",
     }.freeze
 
-    def self.perform
+    def self.perform(all: false)
       new_sync_time = Time.zone.now
       # TODO: Add pagination
       begin
-        sync_users(RegisterAndPartnerApi::User.where(filter: { updated_since: SyncUsersTimer.last_sync }))
+        if all
+          sync_users(RegisterAndPartnerApi::User.all)
+        else
+          sync_users(RegisterAndPartnerApi::User.where(filter: { updated_since: SyncUsersTimer.last_sync }))
+        end
       rescue JsonApiClient::Errors::ClientError
         # This is how the API responds when we run out of pages :/
       end

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -19,11 +19,9 @@ module RegisterAndPartnerApi
       new_sync_time = Time.zone.now
       # TODO: Add pagination
       begin
-        if all
-          sync_users(RegisterAndPartnerApi::User.all)
-        else
-          sync_users(RegisterAndPartnerApi::User.where(filter: { updated_since: SyncUsersTimer.last_sync }))
-        end
+        api_class = RegisterAndPartnerApi::User
+        query = all ? api_class.all : api_class.where(filter: { updated_since: SyncUsersTimer.last_sync })
+        sync_users(query)
       rescue JsonApiClient::Errors::ClientError
         # This is how the API responds when we run out of pages :/
       end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -4,5 +4,6 @@ namespace :cron do
   desc "Updates DelayedJob cron-scheduled tasks"
   task schedule: :environment do
     SyncUsersJob.schedule
+    SyncAllUsersJob.schedule
   end
 end


### PR DESCRIPTION
## Ticket and context

Currently we rely on R&P being nice, and to know what we mean by 'the user was updated' - cause we sent them `updated_since` parameter. 

If it so happens that there is some tiny change here or there (say in that user's schools's cohort's induction programme changes), that doesn't trigger a change of that user's `updated_at` field on R&P, but is important for E&L, we want to have some way of updating it.

And this is this way - nightly job to sync all users.

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them