### PR TITLE
CPDEL-565 change "teacher's" to "ECT's" for mentor view

### DIFF
--- a/app/components/lesson_summary_component.html.erb
+++ b/app/components/lesson_summary_component.html.erb
@@ -50,7 +50,7 @@
   <div class="app-task-list__section">
     <% if @lesson_has_self_study %>
       <p class="govuk-body govuk-!-margin-bottom-2">
-        <%= govuk_link_to "View the teacher's self study materials", lesson_path(@lesson) %>
+        <%= govuk_link_to "View the ECT's self study materials", lesson_path(@lesson) %>
       </p>
     <% elsif @user.admin? %>
       <p class="govuk-body govuk-!-margin-bottom-2">

--- a/app/views/core_induction_programmes/lesson_parts/show.html.erb
+++ b/app/views/core_induction_programmes/lesson_parts/show.html.erb
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if current_user&.mentor? %>
-      <span class="govuk-caption-l">The teacher's self-study materials</span>
+      <span class="govuk-caption-l">The ECT's self-study materials</span>
     <% end %>
     <% if policy(@course_lesson_part.course_lesson).update_progress? && @course_lesson_part.next_lesson_part.nil? %>
       <%= form_with model: @lesson_progress, url: lesson_part_update_progress_path(lesson_part_id: @course_lesson_part.id), method: :put, id: "lesson-progress-form" do |f| %>


### PR DESCRIPTION
## Ticket and context

Ticket: [565](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-565)

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as a mentor, e.g. `ambition-institute-mentor@example.com
3. Go to a module page.
4. Click "View the ECT's self-study materials"
5. You should see the images below 

Module page
![Screenshot 2021-06-18 at 11 23 46](https://user-images.githubusercontent.com/69353998/122547265-c73e8f80-d027-11eb-8413-fc9787411580.png)

Lesson page

![Screenshot 2021-06-18 at 11 23 40](https://user-images.githubusercontent.com/69353998/122547253-c3127200-d027-11eb-8c53-a39a403d97a8.png)
