### PR TITLE
CPDEL-563: Fix importing core induction programes

### DIFF
--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -8,10 +8,10 @@ module RegisterAndPartnerApi
     }.freeze
 
     CIP_TYPES = {
-      ambition: "Ambition Institute",
-      edt: "Education Development Trust",
-      teach_first: "Teach First",
-      ucl: "UCL",
+      ambition: "ambition",
+      edt: "edt",
+      teach_first: "teach_first",
+      ucl: "ucl",
       none: "none",
     }.freeze
 
@@ -43,7 +43,7 @@ module RegisterAndPartnerApi
 
         is_last_page = response.count.zero? || only_repeated_users
         all_user_ids += new_user_ids
-        sleep(1)
+        sleep(1) unless Rails.env.test?
       end
     end
 

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -29,7 +29,7 @@
         "email": "rp-ect-ambition@example.com",
         "full_name": "Joe Bloggs",
         "user_type": "early_career_teacher",
-        "core_induction_programme": "ambition",
+        "core_induction_programme": "ucl",
         "induction_programme_choice": "core_induction_programme"
       }
     },

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe RegisterAndPartnerApi::SyncUsers do
   describe "::perform" do
+    before do
+      create(:core_induction_programme, name: "UCL")
+    end
+
     it "imports all users returned" do
       expect {
         described_class.perform
@@ -37,6 +41,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
 
       record = User.find_by(email: "rp-ect-ambition@example.com")
       expect(record.early_career_teacher?).to be true
+      expect(record.core_induction_programme).not_to be_nil
     end
 
     it "updates an existing user that has changed their email address" do


### PR DESCRIPTION
## Ticket and context

We were not correctly importing core induction programmes :(

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Try to log in as `rp-mentor-ambition@example.com`. You should be able to access your materials. Before this change there was no button to start.
