### PR TITLE
Add spacing between sections in govspeak

### DIFF
--- a/app/models/mentor_material.rb
+++ b/app/models/mentor_material.rb
@@ -30,6 +30,3 @@ class MentorMaterial < ApplicationRecord
     elements_in_order(elements: preloaded_parts, get_previous_element: :previous_mentor_material_part)
   end
 end
-
-MentorMaterialPart.where(mentor_materials: MentorMaterial.where(course_lesson: nil)).delete_all
-MentorMaterial.where(course_lesson: nil).delete_all

--- a/app/models/mentor_material.rb
+++ b/app/models/mentor_material.rb
@@ -30,3 +30,6 @@ class MentorMaterial < ApplicationRecord
     elements_in_order(elements: preloaded_parts, get_previous_element: :previous_mentor_material_part)
   end
 end
+
+MentorMaterialPart.where(mentor_materials: MentorMaterial.where(course_lesson: nil)).delete_all
+MentorMaterial.where(course_lesson: nil).delete_all

--- a/app/webpacker/styles/govspeak/_section.scss
+++ b/app/webpacker/styles/govspeak/_section.scss
@@ -2,6 +2,7 @@
   .section {
     background-color: govuk-colour("light-grey", $legacy: "grey-3");
     padding: 10px;
+    margin: 10px 0;
 
     &:first-child {
       margin-top: 0;


### PR DESCRIPTION
## Ticket and context

Multiple sections one after another had no spacing between them.

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Type `govspeak_test` in the url
```
$Section
Test 1
$Section

$Section
Test 2
$Section
```
Should produce two grey sections separated by a small margin. 