### PR TITLE
Automatically handle generating cip_seed.rb as well as cip_seed_dump.rb

### DIFF
--- a/lib/tasks/cip_seed_dump.rake
+++ b/lib/tasks/cip_seed_dump.rake
@@ -3,4 +3,6 @@
 desc "Dump CIP content into a file"
 task cip_seed_dump: :environment do
   CoreInductionProgrammeExporter.new.run
+
+  sh "rm -f db/seeds/cip_seed.rb && cat db/seeds/cip_seed_dump.rb | sed 's/^\])/\], on_duplicate_key_update: { conflict_target: [:id], columns: :all })/' > db/seeds/cip_seed.rb"
 end


### PR DESCRIPTION
## Ticket and context

vim wasn't a fan of doing this in the editor so i wrote a script for it - figured i'd add it to the rake task

## Code review

### Is there anything weird that code reviewer should know?

why haven't i had to double escape the square brackets? i was expecting ruby to get rid of the escape characters

## Product review

this is entire developer experience stuff and doesn't affect the actual product :)
