### PR TITLE
Add a rake task to invite mentors with unsent invites

### DIFF
--- a/app/models/tracked_email.rb
+++ b/app/models/tracked_email.rb
@@ -16,6 +16,8 @@ class TrackedEmail < ApplicationRecord
   end
 
   def send!(*)
+    return if sent?
+
     self.notify_id = mail_to_send.deliver_now.delivery_method.response.id
     self.sent_to = user.email
     self.sent_at = Time.zone.now

--- a/lib/tasks/invite_mentors.rake
+++ b/lib/tasks/invite_mentors.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :invites do
+  desc "Invite mentor users"
+  task send_mentor_invites: :environment do
+    puts("Sending mentor invites...")
+
+    unsent_emails = InviteEmailMentor.where(sent_at: nil)
+    unsent_emails.each do
+      email.send!(force_send: true)
+    rescue Notifications::Client::RateLimitError
+      sleep(1)
+      email.send!(force_send: true)
+    rescue StandardError
+      puts("Error sending email, id: #{email&.id} ... skipping")
+    end
+
+    puts("Sending mentor invites finished")
+  end
+end


### PR DESCRIPTION
## Ticket and context

I want to send invite emails to all mentors who are on our system. The syncing script made an email for each of them. And this will send them. If they are doing FIP, the `send!` method shouldn't work. 

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.
