### PR TITLE
Update the way we store course year to cip relations

### DIFF
--- a/app/controllers/core_induction_programmes/core_induction_programmes_controller.rb
+++ b/app/controllers/core_induction_programmes/core_induction_programmes_controller.rb
@@ -15,7 +15,7 @@ class CoreInductionProgrammes::CoreInductionProgrammesController < ApplicationCo
   def show
     data_layer.add_cip_info(@core_induction_programme)
     authorize @core_induction_programme
-    redirect_to cip_year_path(@core_induction_programme, @core_induction_programme.course_year_one)
+    redirect_to cip_year_path(@core_induction_programme, @core_induction_programme.course_years.first)
   end
 
   def download_export

--- a/app/controllers/core_induction_programmes/years_controller.rb
+++ b/app/controllers/core_induction_programmes/years_controller.rb
@@ -14,20 +14,21 @@ class CoreInductionProgrammes::YearsController < ApplicationController
   end
 
   def new
+    load_core_induction_programme_from_params
     authorize CourseYear
-    @core_induction_programmes = CoreInductionProgramme.all
     @course_year = CourseYear.new
   end
 
   def create
+    load_core_induction_programme_from_params
     authorize CourseYear
     @course_year = CourseYear.new(course_year_params)
 
+    @course_year.core_induction_programme = @core_induction_programme
     if @course_year.valid?
       @course_year.save!
-      redirect_to year_path(@course_year)
+      redirect_to cip_path(@core_induction_programme)
     else
-      @core_induction_programmes = CoreInductionProgramme.all
       render action: "new"
     end
   end
@@ -55,7 +56,7 @@ private
   end
 
   def course_year_params
-    params.fetch(:course_year, {}).permit(:title, :mentor_title, :content)
+    params.fetch(:course_year, {}).permit(:title, :mentor_title, :content, :core_induction_programme_id)
   end
 
   def fill_data_layer

--- a/app/helpers/load_resources_helper.rb
+++ b/app/helpers/load_resources_helper.rb
@@ -18,15 +18,10 @@ module LoadResourcesHelper
 
     load_core_induction_programme_from_params
 
-    id = params[:year_id] || params[:id]
+    match = (params[:year_id] || params[:id]).match(/year-(\d+)/)
+    @course_year = @core_induction_programme.course_years[match[1].to_i - 1]
 
-    if id == "year-1"
-      @course_year = @core_induction_programme.course_year_one
-    elsif id == "year-2"
-      @course_year = @core_induction_programme.course_year_two
-    else
-      raise ActionController::RoutingError, "Year not found"
-    end
+    raise ActionController::RoutingError, "Year not found" unless @course_year
 
     @course_year
   end
@@ -65,8 +60,7 @@ module LoadResourcesHelper
     load_course_lesson_from_params
 
     match = (params[:lesson_part_id] || params[:id]).match(/part-(\d+)/)
-    id = match[1].to_i - 1
-    @course_lesson_part = @course_lesson.course_lesson_parts_in_order[id]
+    @course_lesson_part = @course_lesson.course_lesson_parts_in_order[match[1].to_i - 1]
 
     raise ActionController::RoutingError, "lesson part not found" unless @course_lesson_part
 

--- a/app/helpers/path_helper.rb
+++ b/app/helpers/path_helper.rb
@@ -11,10 +11,6 @@
 # That's just for module paths, which are three levels deep - mentor material
 # parts are six levels deep, so as you can image get pretty messy!
 module PathHelper
-  def years_path(*args)
-    cip_years_path(*args)
-  end
-
   models = {
     cip: "core_induction_programme",
     year: "course_year",

--- a/app/models/core_induction_programme.rb
+++ b/app/models/core_induction_programme.rb
@@ -1,28 +1,19 @@
 # frozen_string_literal: true
 
 class CoreInductionProgramme < ApplicationRecord
+  # TODO: Remove them after running the migration on all environments
   belongs_to :course_year_one, class_name: "CourseYear", optional: true
   belongs_to :course_year_two, class_name: "CourseYear", optional: true
+
+  has_many :course_years, -> { order(position: :asc) }
+  has_many :course_modules, through: :course_years
+  has_many :course_lessons, through: :course_modules
+  has_many :mentor_materials, through: :course_lessons
+
   has_many :early_career_teacher_profiles
   has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
 
   validates :slug, presence: true
-
-  def course_years
-    CourseYear.where(id: [course_year_one&.id, course_year_two&.id].compact)
-  end
-
-  def course_modules
-    CourseModule.where(course_year: course_years)
-  end
-
-  def course_lessons
-    CourseLesson.where(course_module: course_modules)
-  end
-
-  def mentor_materials
-    MentorMaterial.where(course_lesson: course_lessons)
-  end
 
   def to_param
     slug

--- a/app/models/core_induction_programme_exporter.rb
+++ b/app/models/core_induction_programme_exporter.rb
@@ -2,16 +2,16 @@
 
 class CoreInductionProgrammeExporter
   def run
-    years = CourseYear.order(:title)
     SeedDump.dump(
-      years,
+      CoreInductionProgramme,
       file: "db/seeds/cip_seed_dump.rb",
       exclude: %i[created_at updated_at],
       import: true,
     )
 
+    years = CourseYear.order(:title)
     SeedDump.dump(
-      CoreInductionProgramme,
+      years,
       file: "db/seeds/cip_seed_dump.rb",
       exclude: %i[created_at updated_at],
       import: true,

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -7,6 +7,7 @@ class CourseYear < ApplicationRecord
   has_one :core_induction_programme_one, class_name: "CoreInductionProgramme", foreign_key: :course_year_one_id
   has_one :core_induction_programme_two, class_name: "CoreInductionProgramme", foreign_key: :course_year_two_id
   belongs_to :core_induction_programme
+  acts_as_list scope: :core_induction_programme
   has_many :course_modules, dependent: :delete_all
   has_many :mentor_materials
 
@@ -49,7 +50,7 @@ class CourseYear < ApplicationRecord
   end
 
   def to_param
-    "year-#{self == core_induction_programme.course_year_one ? '1' : '2'}"
+    "year-#{position}"
   end
 
 private

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -6,6 +6,7 @@ class CourseYear < ApplicationRecord
 
   has_one :core_induction_programme_one, class_name: "CoreInductionProgramme", foreign_key: :course_year_one_id
   has_one :core_induction_programme_two, class_name: "CoreInductionProgramme", foreign_key: :course_year_two_id
+  belongs_to :core_induction_programme
   has_many :course_modules, dependent: :delete_all
   has_many :mentor_materials
 
@@ -39,10 +40,6 @@ class CourseYear < ApplicationRecord
     lessons_with_progresses = get_user_lessons_and_progresses(ect_profile, course_lessons)
 
     compute_user_course_module_progress(lessons_with_progresses, modules_in_order)
-  end
-
-  def core_induction_programme
-    core_induction_programme_one || core_induction_programme_two
   end
 
   def title_for(user)

--- a/app/policies/course_year_policy.rb
+++ b/app/policies/course_year_policy.rb
@@ -12,6 +12,6 @@ class CourseYearPolicy < CoreInductionProgrammePolicy
 private
 
   def has_access_to_year?(user, year)
-    has_access_to_cip?(user, year.core_induction_programme_one) || has_access_to_cip?(user, year.core_induction_programme_two)
+    has_access_to_cip?(user, year.core_induction_programme)
   end
 end

--- a/app/views/core_induction_programmes/core_induction_programmes/index.html.erb
+++ b/app/views/core_induction_programmes/core_induction_programmes/index.html.erb
@@ -3,7 +3,6 @@
     <% if current_user&.admin? && @core_induction_programmes.any? %>
       <div class="govuk-button-group">
         <%= govuk_link_to "Download export", download_export_path, button: true%>
-        <%= govuk_link_to "Create CIP Year", new_cip_year_path(@core_induction_programmes.first), button: true %>
       </div>
     <% end %>
     <h1 class="govuk-heading-xl">What is the early career framework?</h1>

--- a/app/views/core_induction_programmes/core_induction_programmes/show.html.erb
+++ b/app/views/core_induction_programmes/core_induction_programmes/show.html.erb
@@ -3,6 +3,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if current_user&.admin? %>
+      <%= govuk_link_to "Create CIP Year", cip_create_year_path(@core_induction_programme), button: true %>
       <%= govuk_link_to "Create CIP Module", cip_create_module_path(@core_induction_programme), button: true %>
       <%= govuk_link_to "Create CIP Lesson", cip_create_lesson_path(@core_induction_programme), button: true %>
     <% end %>

--- a/app/views/core_induction_programmes/years/new.html.erb
+++ b/app/views/core_induction_programmes/years/new.html.erb
@@ -1,15 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Create an additional course year</h1>
-    <%= form_with model: @course_year, url: years_path, method: :post, id: "course-year-create-form" do |f| %>
+    <%= form_with model: @course_year, url: cip_create_year_path(@core_induction_programme), method: :post, id: "course-year-create-form" do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(
-            :core_induction_programme,
-            @core_induction_programmes,
-            :id,
-            :name,
-            legend: { text: "Which provider would you like to create an additional year for?" , class: "govuk-heading-m" }
-          ) %>
       <%= f.govuk_text_field :title, label: { text: 'Course year title' } %>
       <%= f.govuk_text_area(
             :content,

--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -17,6 +17,7 @@
 
     <% if current_user&.admin? %>
       <div class="govuk-button-group">
+        <%= govuk_link_to "Create CIP Year", cip_create_year_path(@cip), button: true %>
         <%= govuk_link_to "Create CIP Module", cip_create_module_path(@cip), button: true %>
         <%= govuk_link_to "Create CIP Lesson", cip_create_lesson_path(@cip), button: true %>
         <%= govuk_link_to "Edit year content", edit_year_path(@course_year), button: true %>

--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -8,7 +8,7 @@
       <%= render SubnavComponent.new do |component| %>
         <% @cip.course_years.each do |course_year| %>
           <%= component.nav_item(path: year_path(course_year)) do %>
-            Year <% course_year.position %>
+            Year <%= course_year.position %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -4,13 +4,12 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= @course_year.title_for(current_user) %></h1>
 
-    <% if @cip.course_year_two_id %>
+    <% if @cip.course_years.count > 1 %>
       <%= render SubnavComponent.new do |component| %>
-        <%= component.nav_item(path: year_path(@cip.course_year_one)) do %>
-          Year 1
-        <% end %>
-        <%= component.nav_item(path: year_path(@cip.course_year_two)) do %>
-          Year 2
+        <% @cip.course_years.each do |course_year| %>
+          <%= component.nav_item(path: year_path(course_year)) do %>
+            Year <% course_year.position %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,10 @@ Rails.application.routes.draw do
     get "create-lesson", to: "lessons#new"
     post "create-lesson", to: "lessons#create"
 
-    resources :years, only: %i[show new create edit update], path: "/", constraints: { id: /year-1|year-2/ } do
+    get "create-year", to: "years#new"
+    post "create-year", to: "years#create"
+
+    resources :years, only: %i[show edit update], path: "/", constraints: { id: /year-1|year-2/ } do
       resources :modules, only: %i[show edit update], path: "/", constraints: { id: /(autumn|spring|summer)-\d+/ } do
         resources :lessons, only: %i[show edit update], path: "/", constraints: { id: /topic-\d+/ } do
           resources :lesson_parts, only: %i[show edit update destroy], path: "/", constraints: { id: /part-\d+/ } do

--- a/db/migrate/20210706133706_restructure_cip_to_year_relation.rb
+++ b/db/migrate/20210706133706_restructure_cip_to_year_relation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RestructureCipToYearRelation < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :course_years, :core_induction_programme, null: true, foreign_key: true, type: :uuid
+    add_column :course_years, :position, :integer, default: 0
+    CourseYear.reset_column_information
+
+    CourseYear.all.each do |course_year|
+      if course_year.core_induction_programme_one
+        course_year.update!(core_induction_programme: course_year.core_induction_programme_one, position: 1)
+      else
+        course_year.update!(core_induction_programme: course_year.core_induction_programme_two, position: 2)
+      end
+    end
+
+    change_column_null :course_years, :core_induction_programme_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_06_102557) do
+ActiveRecord::Schema.define(version: 2021_07_06_133706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -106,6 +106,9 @@ ActiveRecord::Schema.define(version: 2021_07_06_102557) do
     t.string "title", null: false
     t.text "content"
     t.string "mentor_title"
+    t.uuid "core_induction_programme_id", null: false
+    t.integer "position", default: 0
+    t.index ["core_induction_programme_id"], name: "index_course_years_on_core_induction_programme_id"
   end
 
   create_table "delayed_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -216,6 +219,7 @@ ActiveRecord::Schema.define(version: 2021_07_06_102557) do
   add_foreign_key "course_lessons", "course_modules"
   add_foreign_key "course_modules", "course_modules", column: "previous_module_id"
   add_foreign_key "course_modules", "course_years"
+  add_foreign_key "course_years", "core_induction_programmes"
   add_foreign_key "early_career_teacher_profiles", "cohorts"
   add_foreign_key "early_career_teacher_profiles", "core_induction_programmes"
   add_foreign_key "early_career_teacher_profiles", "users"

--- a/spec/cypress/app_commands/scenarios/ect_cip.rb
+++ b/spec/cypress/app_commands/scenarios/ect_cip.rb
@@ -6,4 +6,4 @@ FactoryBot.create(:course_lesson, :with_lesson_part, course_module: course_modul
 
 # You have to create this user in your spec before running this scenario
 ect = User.find("53960d7f-1308-4de1-a56d-de03ea8e1d9c")
-ect.core_induction_programme.update!(course_year_one_id: year.id, course_year_two_id: year.id)
+year.update!(core_induction_programme: ect.core_induction_programme)

--- a/spec/cypress/app_commands/scenarios/mentor_cip.rb
+++ b/spec/cypress/app_commands/scenarios/mentor_cip.rb
@@ -6,4 +6,4 @@ FactoryBot.create(:course_lesson, :with_lesson_part, course_module: course_modul
 
 # You have to create this user in your spec before running this scenario
 mentor = User.find("53960d7f-1308-4de1-a56d-de03ea8e1d9c")
-mentor.core_induction_programme.update!(course_year_one_id: year.id, course_year_two_id: year.id)
+year.update!(core_induction_programme: mentor.core_induction_programme)

--- a/spec/cypress/integration/CipYears.feature
+++ b/spec/cypress/integration/CipYears.feature
@@ -2,7 +2,7 @@ Feature: Core Induction Programme years
   Users should be able to view and sometimes edit cip years.
 
   Scenario: Admins can edit years
-    Given core_induction_programme was created as "with_course_year"
+    Given course_year was created
     And I am logged in as "admin"
     And I am on "core induction programme show" page
 

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -24,7 +24,7 @@ describe("Accessibility", () => {
         cy.login("admin");
         cy.appEval(
           `CourseLessonPart
-            .includes(course_lesson: { course_module: { course_year: [:core_induction_programme_one] }}).all
+            .includes(course_lesson: { course_module: { course_year: [:core_induction_programme] }}).all
             .map { |part| {
               part: part.to_param,
               lesson: part.course_lesson.to_param,
@@ -71,7 +71,7 @@ describe("Accessibility", () => {
         cy.login("admin");
         cy.appEval(
           `MentorMaterialPart
-            .includes(mentor_material: { course_lesson: { course_module: { course_year: [:core_induction_programme_one] }}}).all
+            .includes(mentor_material: { course_lesson: { course_module: { course_year: [:core_induction_programme] }}}).all
             .map { |part| {
               part: part.to_param,
               material: part.mentor_material.to_param,

--- a/spec/factories/core_induction_programmes.rb
+++ b/spec/factories/core_induction_programmes.rb
@@ -4,10 +4,5 @@ FactoryBot.define do
   factory :core_induction_programme do
     name { "Test Core induction programme" }
     sequence(:slug) { |n| "test-cip-#{n}" }
-
-    trait :with_course_year do
-      course_year_one_id { FactoryBot.create(:course_year).id }
-      course_year_two_id { FactoryBot.create(:course_year).id }
-    end
   end
 end

--- a/spec/factories/course_module.rb
+++ b/spec/factories/course_module.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :course_module do
     title { "Test Course module" }
     ect_summary { "No content" }
-    course_year { FactoryBot.create(:course_year, :with_cip) }
+    course_year { FactoryBot.create(:course_year) }
 
     trait :with_previous do
       after :build do |course_module|

--- a/spec/factories/course_year.rb
+++ b/spec/factories/course_year.rb
@@ -6,9 +6,5 @@ FactoryBot.define do
     content { "No content" }
     core_induction_programme { FactoryBot.create(:core_induction_programme) }
     position { 1 }
-
-    after(:create) do |year|
-      year.core_induction_programme.update!(course_year_one: year)
-    end
   end
 end

--- a/spec/factories/course_year.rb
+++ b/spec/factories/course_year.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       after(:create) do |year|
         cip = FactoryBot.create(:core_induction_programme,
                                 course_year_one: year)
-        year.core_induction_programme_one = cip
+        year.core_induction_programme = cip
       end
     end
   end

--- a/spec/factories/course_year.rb
+++ b/spec/factories/course_year.rb
@@ -4,13 +4,11 @@ FactoryBot.define do
   factory :course_year do
     title { "Test Course year" }
     content { "No content" }
+    core_induction_programme { FactoryBot.create(:core_induction_programme) }
+    position { 1 }
 
-    trait :with_cip do
-      after(:create) do |year|
-        cip = FactoryBot.create(:core_induction_programme,
-                                course_year_one: year)
-        year.core_induction_programme = cip
-      end
+    after(:create) do |year|
+      year.core_induction_programme.update!(course_year_one: year)
     end
   end
 end

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -6,7 +6,7 @@ describe CipBreadcrumbHelper, type: :helper do
   let(:early_career_teacher) { FactoryBot.build(:user, :early_career_teacher) }
   let(:mentor) { FactoryBot.build(:user, :mentor) }
   let(:admin) { FactoryBot.build(:user, :admin) }
-  let(:course_year) { FactoryBot.create(:course_year, :with_cip, mentor_title: "Mentor title") }
+  let(:course_year) { FactoryBot.create(:course_year, mentor_title: "Mentor title") }
   let(:core_induction_programme) { course_year.core_induction_programme }
   let(:course_module) { create(:course_module, course_year: course_year) }
   let(:course_lesson) { create(:course_lesson, course_module: course_module) }

--- a/spec/helpers/path_helper_spec.rb
+++ b/spec/helpers/path_helper_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe PathHelper, type: :helper do
   let(:course_year) { FactoryBot.create(:course_year, mentor_title: "Mentor title") }
-  let!(:core_induction_programme) { create(:core_induction_programme, course_year_one: course_year) }
+  let!(:core_induction_programme) { course_year.core_induction_programme }
   let(:course_module) { create(:course_module, course_year: course_year) }
   let(:course_lesson) { create(:course_lesson, :with_lesson_part, course_module: course_module) }
   let(:course_lesson_part) { course_lesson.course_lesson_parts[0] }
@@ -18,12 +18,6 @@ RSpec.describe PathHelper, type: :helper do
   let(:expected_lesson_part_path) { "#{expected_lesson_path}/#{course_lesson_part.to_param}" }
   let(:expected_mentor_material_path) { "#{expected_lesson_path}/mentoring/#{mentor_material.to_param}" }
   let(:expected_mentor_material_part_path) { "#{expected_mentor_material_path}/#{mentor_material_part.to_param}" }
-
-  describe "#years_path" do
-    it "returns correct path" do
-      expect(years_path(cip_id: core_induction_programme.to_param)).to eq(expected_cip_path)
-    end
-  end
 
   describe "#edit_year_path" do
     it "returns correct path" do

--- a/spec/models/core_induction_programme.rb
+++ b/spec/models/core_induction_programme.rb
@@ -10,15 +10,4 @@ RSpec.describe CoreInductionProgramme, type: :model do
     it { is_expected.to belong_to(:course_year_one).optional }
     it { is_expected.to belong_to(:course_year_two).optional }
   end
-
-  describe "course_years" do
-    it "returns multiple course years for a single core_induction_programme" do
-      core_induction_programme = FactoryBot.create(:core_induction_programme)
-      course_year_one = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
-      course_year_two = FactoryBot.create(:course_year, core_induction_programme: core_induction_programme)
-
-      expect(course_year_one.core_induction_programme).to eql(course_year_two.core_induction_programme)
-      expect(core_induction_programme.course_years.count).to eq(2)
-    end
-  end
 end

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -3,15 +3,6 @@
 require "rails_helper"
 
 RSpec.describe CourseYear, type: :model do
-  it "can be created" do
-    expect {
-      CourseYear.create(
-        title: "Test Course year",
-        content: "No content",
-      )
-    }.to change { CourseYear.count }.by(1)
-  end
-
   describe "associations" do
     it { is_expected.to have_many(:course_modules) }
     it { is_expected.to belong_to(:core_induction_programme) }

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe CourseYear, type: :model do
 
   describe "associations" do
     it { is_expected.to have_many(:course_modules) }
-    it { is_expected.to have_one(:core_induction_programme_one) }
-    it { is_expected.to have_one(:core_induction_programme_two) }
+    it { is_expected.to belong_to(:core_induction_programme) }
   end
 
   describe "validations" do

--- a/spec/policies/course_lesson_part_policy_spec.rb
+++ b/spec/policies/course_lesson_part_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CourseLessonPartPolicy, type: :policy do
   let(:course_lesson) { create(:course_lesson, course_module: course_module) }
   let(:course_module) { create(:course_module, course_year: course_year) }
   let(:course_year) { create(:course_year) }
-  let(:cip_for_lesson_part) { create(:core_induction_programme, course_year_two: course_year) }
+  let(:cip_for_lesson_part) { course_year.core_induction_programme }
 
   context "admin user" do
     let(:user) { create(:user, :admin) }

--- a/spec/policies/course_lesson_policy_spec.rb
+++ b/spec/policies/course_lesson_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CourseLessonPolicy, type: :policy do
   let(:course_lesson) { create(:course_lesson, course_module: course_module) }
   let(:course_module) { create(:course_module, course_year: course_year) }
   let(:course_year) { create(:course_year) }
-  let(:cip_for_lesson) { create(:core_induction_programme, course_year_two: course_year) }
+  let(:cip_for_lesson) { course_year.core_induction_programme }
 
   context "admin user" do
     let(:user) { create(:user, :admin) }

--- a/spec/policies/course_module_policy_spec.rb
+++ b/spec/policies/course_module_policy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CourseModulePolicy, type: :policy do
   subject { described_class.new(user, course_module) }
   let(:course_module) { create(:course_module, course_year: course_year) }
   let(:course_year) { create(:course_year) }
-  let(:cip_for_module) { create(:core_induction_programme, course_year_two: course_year) }
+  let(:cip_for_module) { course_year.core_induction_programme }
 
   context "admin user" do
     let(:user) { create(:user, :admin) }

--- a/spec/policies/course_year_policy_spec.rb
+++ b/spec/policies/course_year_policy_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe CourseYearPolicy, type: :policy do
   subject { described_class.new(user, course_year) }
   let(:course_year) { create(:course_year) }
-  let(:cip_for_year) { create(:core_induction_programme, course_year_one: course_year) }
+  let(:cip_for_year) { course_year.core_induction_programme }
 
   context "admin user" do
     let(:user) { create(:user, :admin) }

--- a/spec/requests/core_induction_programme/core_induction_programme_spec.rb
+++ b/spec/requests/core_induction_programme/core_induction_programme_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Core Induction Programme", type: :request do
-  let!(:core_induction_programme) { create(:core_induction_programme, :with_course_year) }
+  let!(:course_year) { create(:course_year) }
+  let(:core_induction_programme) { course_year.core_induction_programme }
 
   describe "when an admin user is logged in" do
     before do
@@ -21,7 +22,7 @@ RSpec.describe "Core Induction Programme", type: :request do
     describe "GET /:id" do
       it "redirects to year page" do
         get "/#{core_induction_programme.to_param}"
-        expect(response).to redirect_to("/#{core_induction_programme.to_param}/#{core_induction_programme.course_year_one.to_param}")
+        expect(response).to redirect_to("/#{core_induction_programme.to_param}/#{core_induction_programme.course_years[0].to_param}")
       end
     end
   end
@@ -42,7 +43,7 @@ RSpec.describe "Core Induction Programme", type: :request do
     describe "GET /:id" do
       it "redirects to year page" do
         get "/#{core_induction_programme.to_param}"
-        expect(response).to redirect_to("/#{core_induction_programme.to_param}/#{core_induction_programme.course_year_one.to_param}")
+        expect(response).to redirect_to("/#{core_induction_programme.to_param}/#{core_induction_programme.course_years[0].to_param}")
       end
 
       it "raises an error when an ECT tries to access a cip they are not enrolled on" do

--- a/spec/requests/core_induction_programme/course_lesson_part_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_part_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Core Induction Programme Lesson Part", type: :request do
   let(:course_lesson) { course_lesson_part.course_lesson }
   let(:course_module) { course_lesson.course_module }
   let(:course_year) { course_module.course_year }
-  let(:cip) { course_year.core_induction_programme_one }
+  let(:cip) { course_year.core_induction_programme }
   let(:course_lesson_path) { "/#{cip.to_param}/#{course_year.to_param}/#{course_module.to_param}/#{course_lesson.to_param}" }
   let(:course_lesson_part_path) { "#{course_lesson_path}/#{course_lesson_part.to_param}" }
 

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Core Induction Programme Lesson", type: :request do
   let(:cip) { create(:core_induction_programme) }
-  let(:course_year) { FactoryBot.create(:course_year, core_induction_programme_one: cip) }
+  let(:course_year) { FactoryBot.create(:course_year, core_induction_programme: cip) }
   let(:course_module) { FactoryBot.create(:course_module, course_year: course_year) }
   let(:course_lesson) { FactoryBot.create(:course_lesson, course_module: course_module) }
   let(:course_lesson_path) { "/#{cip.to_param}/#{course_year.to_param}/#{course_module.to_param}/#{course_lesson.to_param}" }

--- a/spec/requests/core_induction_programme/course_module_spec.rb
+++ b/spec/requests/core_induction_programme/course_module_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Core Induction Programme Module", type: :request do
-  let(:core_induction_programme) { FactoryBot.create(:core_induction_programme, :with_course_year) }
-  let(:course_module) { FactoryBot.create(:course_module, course_year: core_induction_programme.course_year_one) }
-  let(:course_module_path) { "/#{core_induction_programme.to_param}/#{course_module.course_year.to_param}/#{course_module.to_param}" }
+  let!(:course_year) { FactoryBot.create(:course_year) }
+  let!(:core_induction_programme) { course_year.core_induction_programme }
+  let(:course_module) { FactoryBot.create(:course_module, course_year: course_year) }
+  let(:course_module_path) { "/#{course_year.core_induction_programme.to_param}/#{course_year.to_param}/#{course_module.to_param}" }
   let(:second_course_module) { FactoryBot.create(:course_module, title: "Second module title", previous_module: course_module) }
 
   describe "when an admin user is logged in" do

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Core Induction Programme Year", type: :request do
-  let(:course_year) { FactoryBot.create(:course_year, :with_cip) }
+  let(:course_year) { FactoryBot.create(:course_year) }
   let(:course_year_path) { "/#{cip.to_param}/#{course_year.to_param}" }
   let(:cip) { course_year.core_induction_programme }
 
@@ -20,17 +20,17 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
 
-    describe "GET /years/new" do
+    describe "GET /:cip_id/create-year" do
       it "renders the cip new years page" do
-        get "/#{cip.to_param}/new"
+        get "/#{cip.to_param}/create-year"
         expect(response).to render_template(:new)
       end
     end
 
-    describe "POST /years" do
-      it "creates a new year, redirecting to the year" do
+    describe "POST /:cip_id/create-year" do
+      it "creates a new year, redirecting to the cip page" do
         create_course_year
-        expect(response.location).to match("/year-\d+$")
+        expect(response.location).to match("/test-cip-")
       end
     end
 
@@ -66,9 +66,9 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       sign_in user
     end
 
-    describe "GET /years/new" do
+    describe "GET /:cip_id/create-year" do
       it "raises an error when trying to create a new year page" do
-        expect { get "/#{cip.to_param}/new" }.to raise_error Pundit::NotAuthorizedError
+        expect { get "/#{cip.to_param}/create-year" }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
 
-    describe "POST /years" do
+    describe "POST /:cip_id/create-year" do
       it "raises an error when trying to post a new year" do
         expect(create_course_year).to redirect_to("/users/sign_in")
       end
@@ -113,17 +113,17 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
   end
-end
 
 private
 
-def create_course_year
-  post "/#{cip.to_param}", params: { course_year: {
-    title: "Additional year title",
-    content: "Additional year content",
-  } }
-end
+  def create_course_year
+    post "/#{cip.to_param}/create-year", params: { course_year: {
+      title: "Additional year title",
+      content: "Additional year content",
+    } }
+  end
 
-def create_cip
-  FactoryBot.create(:core_induction_programme, course_year_one: course_year)
+  def create_cip
+    FactoryBot.create(:core_induction_programme, course_year_one: course_year)
+  end
 end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Core Induction Programme Year", type: :request do
   let(:course_year) { FactoryBot.create(:course_year, :with_cip) }
   let(:course_year_path) { "/#{cip.to_param}/#{course_year.to_param}" }
-  let(:cip) { course_year.core_induction_programme_one }
+  let(:cip) { course_year.core_induction_programme }
 
   describe "when an admin user is logged in" do
     before do
@@ -27,7 +27,7 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
 
-    xdescribe "POST /years" do
+    describe "POST /years" do
       it "creates a new year, redirecting to the year" do
         create_course_year
         expect(response.location).to match("/year-\d+$")
@@ -72,7 +72,7 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
 
-    xdescribe "POST /years" do
+    describe "POST /years" do
       it "raises an error when trying to post a new year" do
         expect { create_course_year }.to raise_error Pundit::NotAuthorizedError
       end
@@ -93,7 +93,7 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
     end
 
-    xdescribe "POST /years" do
+    describe "POST /years" do
       it "raises an error when trying to post a new year" do
         expect(create_course_year).to redirect_to("/users/sign_in")
       end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Core Induction Programme Year", type: :request do
   let(:course_year) { FactoryBot.create(:course_year) }
   let(:course_year_path) { "/#{cip.to_param}/#{course_year.to_param}" }
-  let(:cip) { course_year.core_induction_programme }
+  let!(:cip) { course_year.core_induction_programme }
 
   describe "when an admin user is logged in" do
     before do
@@ -51,7 +51,6 @@ RSpec.describe "Core Induction Programme Year", type: :request do
       end
 
       it "redirects to the year page and updates content when saving changes" do
-        create_cip
         put course_year_path, params: { commit: "Save changes", course_year: { content: "Adding new content" } }
         expect(response).to redirect_to("/#{cip.to_param}/#{course_year.to_param}")
         expect(course_year.reload.content).to include("Adding new content")
@@ -121,9 +120,5 @@ private
       title: "Additional year title",
       content: "Additional year content",
     } }
-  end
-
-  def create_cip
-    FactoryBot.create(:core_induction_programme, course_year_one: course_year)
   end
 end

--- a/spec/requests/core_induction_programme/mentor_material_spec.rb
+++ b/spec/requests/core_induction_programme/mentor_material_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Mentor materials", type: :request do
   let(:course_lesson) { mentor_material.course_lesson }
   let(:course_module) { course_lesson.course_module }
   let(:course_year) { course_module.course_year }
-  let!(:cip) { course_year.core_induction_programme_one }
+  let!(:cip) { course_year.core_induction_programme }
 
   let(:course_lesson_path) { "/#{cip.to_param}/#{course_year.to_param}/#{course_module.to_param}/#{course_lesson.to_param}" }
   let(:mentor_material_path) { "#{course_lesson_path}/mentoring/#{mentor_material.to_param}" }

--- a/spec/requests/core_induction_programme/mentor_materials_part_request_spec.rb
+++ b/spec/requests/core_induction_programme/mentor_materials_part_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "MentorMaterialsParts", type: :request do
   let(:course_lesson) { mentor_material.course_lesson }
   let(:course_module) { course_lesson.course_module }
   let(:course_year) { course_module.course_year }
-  let(:cip) { course_year.core_induction_programme_one }
+  let(:cip) { course_year.core_induction_programme }
 
   let(:mentor_material_path) { "/#{cip.to_param}/#{course_year.to_param}/#{course_module.to_param}/#{course_lesson.to_param}/mentoring/#{mentor_material.to_param}" }
   let(:mentor_material_part_path) { "#{mentor_material_path}/#{mentor_material_part.to_param}" }


### PR DESCRIPTION
## Ticket and context

I think it is pretty annoying to try to find the right cip on a year from two relations. I think it will be easier to handle things if we go back towards course year belonging to a core induction programme, with an integer position. 

This is part one, which has to be released across all environments first. Part two will remove the unused fields and code. We can't remove them just yet, cause migrating things would be a lot harder that way. 

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them
