### PR TITLE
CPDEL-653 check user registration is complete

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -122,6 +122,11 @@ private
       user.errors.add :induction_programme_choice, "Your school has not selected a core induction programme for you, contact your school induction coordinator"
     end
 
+    early_user = InviteEmailMentor.find_by(user: user.id) || InviteEmailEct.find_by(user: user.id)
+    unless user.registered_early_career_teacher? || user.registered_mentor? || early_user.sent_at.present?
+      user.errors.add :email, "Please complete your registration on R&P"
+    end
+
     user
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -122,18 +122,17 @@ private
       user.errors.add :induction_programme_choice, "Your school has not selected a core induction programme for you, contact your school induction coordinator"
     end
 
-    return user if user_accessed_service_before_cutoff?(user)
+    return user if user_already_accessed_the_service?(user)
 
-    unless user.registered_early_career_teacher? || user.registered_mentor?
-      user.errors.add :email, "Please complete your registration on R&P"
+    unless user.registered_participant?
+      user.errors.add :email, "Please complete your registration"
     end
 
     user
   end
 
-  def user_accessed_service_before_cutoff?(user)
-    cutoff_date = user.mentor? ? InviteEmailMentor::INVITES_SENT_FROM : InviteEmailEct::INVITES_SENT_FROM
-    InviteEmailMentor.where("sent_at < ?", cutoff_date).find_by(user: user.id).present? ||
-      InviteEmailEct.where("sent_at < ?", cutoff_date).find_by(user: user.id).present?
+  def user_already_accessed_the_service?(user)
+    InviteEmailMentor.where.not(sent_at: nil).find_by(user: user.id).present? ||
+      InviteEmailEct.where.not(sent_at: nil).find_by(user: user.id).present?
   end
 end

--- a/app/models/invite_email_ect.rb
+++ b/app/models/invite_email_ect.rb
@@ -8,7 +8,7 @@ class InviteEmailEct < TrackedEmail
   end
 
   def send!(force_send: false)
-    return unless user.is_on_core_induction_programme?
+    return unless user.is_on_core_induction_programme? && user.registered_participant?
 
     can_send_automatically = Time.zone.now >= INVITES_SENT_FROM
     if can_send_automatically || force_send

--- a/app/models/invite_email_mentor.rb
+++ b/app/models/invite_email_mentor.rb
@@ -8,7 +8,7 @@ class InviteEmailMentor < TrackedEmail
   end
 
   def send!(force_send: false)
-    return unless user.is_on_core_induction_programme?
+    return unless user.is_on_core_induction_programme? && user.registered_participant?
 
     can_send_automatically = Time.zone.now >= INVITES_SENT_FROM
     if can_send_automatically || force_send

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,16 +30,12 @@ class User < ApplicationRecord
     mentor_profile.present?
   end
 
-  def registered_mentor?
-    mentor_profile&.registration_completed?
-  end
-
-  def registered_early_career_teacher?
-    early_career_teacher_profile&.registration_completed?
-  end
-
   def participant?
     participant_profile.present?
+  end
+
+  def registered_participant?
+    participant_profile&.registration_completed?
   end
 
   def participant_profile

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,14 @@ class User < ApplicationRecord
     mentor_profile.present?
   end
 
+  def registered_mentor?
+    mentor_profile&.registration_completed?
+  end
+
+  def registered_early_career_teacher?
+    early_career_teacher_profile&.registration_completed?
+  end
+
   def participant?
     participant_profile.present?
   end

--- a/app/services/invite_participants.rb
+++ b/app/services/invite_participants.rb
@@ -15,9 +15,9 @@ class InviteParticipants
   end
 
   def self.create_invite_email_for_user(user)
-    if user.registered_mentor?
+    if user.registered_participant? && user.mentor?
       InviteEmailMentor.find_or_create_by!(user: user, sent_at: nil)
-    elsif user.registered_early_career_teacher?
+    elsif user.registered_participant? && user.early_career_teacher?
       InviteEmailEct.find_or_create_by!(user: user, sent_at: nil)
     end
   end

--- a/app/services/invite_participants.rb
+++ b/app/services/invite_participants.rb
@@ -15,9 +15,9 @@ class InviteParticipants
   end
 
   def self.create_invite_email_for_user(user)
-    if user.mentor?
+    if user.registered_mentor?
       InviteEmailMentor.find_or_create_by!(user: user, sent_at: nil)
-    elsif user.early_career_teacher?
+    elsif user.registered_early_career_teacher?
       InviteEmailEct.find_or_create_by!(user: user, sent_at: nil)
     end
   end

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -75,6 +75,7 @@ module RegisterAndPartnerApi
         user_type: user_from_api.attributes[:attributes][:user_type],
         cip: user_from_api.attributes[:attributes][:core_induction_programme],
         induction_programme_choice: user_from_api.attributes[:attributes][:induction_programme_choice],
+        registration_completed: user_from_api.attributes[:attributes][:registration_completed],
       }
     end
 
@@ -95,6 +96,7 @@ module RegisterAndPartnerApi
       user.save!
       profile.core_induction_programme = get_core_induction_programme(attributes)
       profile.induction_programme_choice = attributes[:induction_programme_choice]
+      profile.registration_completed = attributes[:registration_completed]
       profile.save!
     end
 

--- a/db/migrate/20210709100154_add_registration_completed_to_early_career_teacher_profiles.rb
+++ b/db/migrate/20210709100154_add_registration_completed_to_early_career_teacher_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRegistrationCompletedToEarlyCareerTeacherProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :early_career_teacher_profiles, :registration_completed, :boolean, default: false
+  end
+end

--- a/db/migrate/20210709100207_add_registration_completed_to_mentor_profiles.rb
+++ b/db/migrate/20210709100207_add_registration_completed_to_mentor_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRegistrationCompletedToMentorProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :mentor_profiles, :registration_completed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_154859) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "induction_programme_choice", default: "not_yet_known"
+    t.boolean "registration_completed", default: false
     t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
@@ -169,6 +170,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_154859) do
     t.uuid "core_induction_programme_id"
     t.uuid "cohort_id"
     t.string "induction_programme_choice", default: "not_yet_known"
+    t.boolean "registration_completed", default: false
     t.index ["cohort_id"], name: "index_mentor_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_mentor_profiles_on_core_induction_programme_id"
     t.index ["user_id"], name: "index_mentor_profiles_on_user_id"

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -27,12 +27,14 @@ unless Rails.env.production?
     ect_user = User.find_or_create_by!(email: "#{cip_name_for_email}-early-career-teacher@example.com") do |u|
       u.full_name = "#{cip.name} ECT User"
     end
-    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: cip, induction_programme_choice: "core_induction_programme")
+    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: cip,
+                                                 induction_programme_choice: "core_induction_programme", registration_completed: true)
 
     mentor_user = User.find_or_create_by!(email: "#{cip_name_for_email}-mentor@example.com") do |u|
       u.full_name = "#{cip.name} Mentor User"
     end
-    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: cip, induction_programme_choice: "core_induction_programme")
+    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: cip,
+                                     induction_programme_choice: "core_induction_programme", registration_completed: true)
   end
 
   # CIP-less users

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     user
     core_induction_programme
     induction_programme_choice { "core_induction_programme" }
+    registration_completed { true }
   end
 end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     user
     core_induction_programme
     induction_programme_choice { "core_induction_programme" }
+    registration_completed { true }
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -8,7 +8,8 @@
         "full_name": "Lead Provider",
         "user_type": "mentor",
         "core_induction_programme": "ucl",
-        "induction_programme_choice": "core_induction_programme"
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": true
       }
     },
     {
@@ -19,7 +20,8 @@
         "full_name": "Induction Tutor",
         "user_type": "mentor",
         "core_induction_programme": "none",
-        "induction_programme_choice": "core_induction_programme"
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": true
       }
     },
     {
@@ -30,7 +32,8 @@
         "full_name": "Joe Bloggs",
         "user_type": "early_career_teacher",
         "core_induction_programme": "ucl",
-        "induction_programme_choice": "core_induction_programme"
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": true
       }
     },
     {
@@ -41,7 +44,8 @@
         "full_name": "Jane Doe",
         "user_type": "other",
         "core_induction_programme": "ucl",
-        "induction_programme_choice": "core_induction_programme"
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": false
       }
     },
     {
@@ -52,7 +56,20 @@
         "full_name": "Steve Austin",
         "user_type": "early_career_teacher",
         "core_induction_programme": "edt",
-        "induction_programme_choice": "full_induction_programme"
+        "induction_programme_choice": "full_induction_programme",
+        "registration_completed": true
+      }
+    },
+      {
+      "id": "d97fbf35-845g-3g62-q256-bde676314m35",
+      "type": "user",
+      "attributes": {
+        "email": "unverified_user@example.com",
+        "full_name": "Dwayne Johnson",
+        "user_type": "early_career_teacher",
+        "core_induction_programme": "teach_first",
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": false
       }
     }
   ]

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe TrackedEmail, type: :model do
         invite_email_ect.send!(force_send: true)
         expect(invite_email_ect.reload.sent?).to be_falsey
       end
+
+      it "does not send the email to a cip ect user if they have not completed registration, even if forced" do
+        ect.early_career_teacher_profile.update!(registration_completed: false)
+        invite_email_ect.send!(force_send: true)
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
     end
 
     context "on cutoff date" do
@@ -100,6 +106,12 @@ RSpec.describe TrackedEmail, type: :model do
         expect(invite_email_ect.reload.sent?).to be_falsey
       end
 
+      it "does not send the email to a cip ect user if they have not completed registration" do
+        ect.early_career_teacher_profile.update!(registration_completed: false)
+        invite_email_ect.send!
+        expect(invite_email_ect.reload.sent?).to be_falsey
+      end
+
       it "sends only one email" do
         invite_email_ect.send!
         time = invite_email_ect.sent_at
@@ -146,6 +158,12 @@ RSpec.describe TrackedEmail, type: :model do
         invite_email_mentor.send!(force_send: true)
         expect(invite_email_mentor.reload.sent?).to be_falsey
       end
+
+      it "does not send the email to a cip mentor if they have not completed registration, even if forced" do
+        mentor.mentor_profile.update!(registration_completed: false)
+        invite_email_mentor.send!(force_send: true)
+        expect(invite_email_mentor.reload.sent?).to be_falsey
+      end
     end
 
     context "on cutoff date" do
@@ -180,6 +198,12 @@ RSpec.describe TrackedEmail, type: :model do
 
       it "does not send the email to mentor if induction programme is not yet known" do
         mentor.mentor_profile.not_yet_known!
+        invite_email_mentor.send!
+        expect(invite_email_mentor.reload.sent?).to be_falsey
+      end
+
+      it "does not send the email to a cip mentor if they have not completed registration" do
+        mentor.mentor_profile.update!(registration_completed: false)
         invite_email_mentor.send!
         expect(invite_email_mentor.reload.sent?).to be_falsey
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#registered_early_career_teacher" do
+  describe "#registered_partcipant" do
     it "is expected to be true when the user has registered on the service as an ect" do
       user = create(:user, :early_career_teacher)
 
@@ -116,9 +116,7 @@ RSpec.describe User, type: :model do
 
       expect(user.registered_participant?).to be false
     end
-  end
 
-  describe "#registered_mentor" do
     it "is expected to be true when the user has registered on the service as an mentor" do
       user = create(:user, :mentor)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,14 +107,14 @@ RSpec.describe User, type: :model do
     it "is expected to be true when the user has registered on the service as an ect" do
       user = create(:user, :early_career_teacher)
 
-      expect(user.registered_early_career_teacher?).to be true
+      expect(user.registered_participant?).to be true
     end
 
     it "is expected to be true when the user is an ect but has not completed the registration" do
       user = create(:user, :early_career_teacher)
       user.early_career_teacher_profile.update!(registration_completed: false)
 
-      expect(user.registered_early_career_teacher?).to be false
+      expect(user.registered_participant?).to be false
     end
   end
 
@@ -122,14 +122,14 @@ RSpec.describe User, type: :model do
     it "is expected to be true when the user has registered on the service as an mentor" do
       user = create(:user, :mentor)
 
-      expect(user.registered_mentor?).to be true
+      expect(user.registered_participant?).to be true
     end
 
     it "is expected to be true when the user is a mentor but has not completed the registration" do
       user = create(:user, :mentor)
       user.mentor_profile.update!(registration_completed: false)
 
-      expect(user.registered_mentor?).to be false
+      expect(user.registered_participant?).to be false
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -102,4 +102,34 @@ RSpec.describe User, type: :model do
       expect(user.participant?).to be false
     end
   end
+
+  describe "#registered_early_career_teacher" do
+    it "is expected to be true when the user has registered on the service as an ect" do
+      user = create(:user, :early_career_teacher)
+
+      expect(user.registered_early_career_teacher?).to be true
+    end
+
+    it "is expected to be true when the user is an ect but has not completed the registration" do
+      user = create(:user, :early_career_teacher)
+      user.early_career_teacher_profile.update!(registration_completed: false)
+
+      expect(user.registered_early_career_teacher?).to be false
+    end
+  end
+
+  describe "#registered_mentor" do
+    it "is expected to be true when the user has registered on the service as an mentor" do
+      user = create(:user, :mentor)
+
+      expect(user.registered_mentor?).to be true
+    end
+
+    it "is expected to be true when the user is a mentor but has not completed the registration" do
+      user = create(:user, :mentor)
+      user.mentor_profile.update!(registration_completed: false)
+
+      expect(user.registered_mentor?).to be false
+    end
+  end
 end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe "Users::Sessions", type: :request do
         end
       end
 
+      context "when a user isn't registered but has accessed the service prior to public beta" do
+        it "redirects to dashboard" do
+          ect.early_career_teacher_profile.update!(registration_completed: false)
+          InviteEmailEct.create!(user: ect, sent_at: Time.zone.now)
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to redirect_to(dashboard_path)
+          expect(ect.reload.last_sign_in_at).not_to be_nil
+        end
+      end
+
+      context "when a user isn't registered and has not accessed the service prior to public beta" do
+        it "redirects to dashboard" do
+          ect.early_career_teacher_profile.update!(registration_completed: false)
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to render_template(:new)
+          expect(ect.reload.last_sign_in_at).to be_nil
+        end
+      end
+
       context "when a user's induction programme choice is a full induction programme" do
         it "renders sign_in page" do
           ect.early_career_teacher_profile.full_induction_programme!
@@ -122,6 +141,25 @@ RSpec.describe "Users::Sessions", type: :request do
           post "/users/sign_in", params: { user: { email: mentor.email } }
           expect(response).to redirect_to(dashboard_path)
           expect(mentor.reload.last_sign_in_at).not_to be_nil
+        end
+      end
+
+      context "when a user isn't registered but has accessed the service prior to public beta" do
+        it "redirects to dashboard" do
+          mentor.mentor_profile.update!(registration_completed: false)
+          InviteEmailEct.create!(user: mentor, sent_at: Time.zone.now)
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to redirect_to(dashboard_path)
+          expect(mentor.reload.last_sign_in_at).not_to be_nil
+        end
+      end
+
+      context "when a user isn't registered and has not accessed the service prior to public beta" do
+        it "redirects to dashboard" do
+          mentor.mentor_profile.update!(registration_completed: false)
+          post "/users/sign_in", params: { user: { email: mentor.email } }
+          expect(response).to render_template(:new)
+          expect(mentor.reload.last_sign_in_at).to be_nil
         end
       end
 

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
     it "imports all users returned" do
       expect {
         described_class.perform
-      }.to change(User, :count).by(4)
+      }.to change(User, :count).by(5)
     end
 
     it "does not create the users again" do
       expect {
         described_class.perform
         described_class.perform
-      }.to change(User, :count).by(4)
+      }.to change(User, :count).by(5)
     end
 
     it "does not create a user when given a user type of other" do
@@ -26,7 +26,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
 
       record = User.find_by(email: "user_type_other@example.com")
       expect(record.nil?).to be true
-      expect(User.count).to eql(4)
+      expect(User.count).to eql(5)
     end
 
     it "creates users with correct attributes" do
@@ -50,7 +50,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
-      expect(User.count).to eql(4)
+      expect(User.count).to eql(5)
       expect(record.email).to eql("mentor@example.com")
     end
 


### PR DESCRIPTION
## Ticket and context

Ticket: [653](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-653)

## Code review

### Is there anything weird that code reviewer should know?
- We need to check that has registered on R&P side before allowing them to access the materials on E&L. R&P haven't started this process fully yet but we can our initial structure for it. 

An automatic assignment of false has been added on R&P as a placeholder - see [R&P 682](https://github.com/DFE-Digital/early-careers-framework/pull/682#partial-pull-merging)

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
