### PR TITLE
CPDEL-697-set-cipYear-datalayer-to-year-position

### DIFF
--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -40,7 +40,7 @@ class AnalyticsDataLayer
 
   def add_year_info(year)
     add_cip_info(year.core_induction_programme) if year
-    @analytics_data[:cipYear] = year.title if year
+    @analytics_data[:cipYear] = "Year #{year.position}" if year
   end
 
   def add_module_info(course_module)

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -15,10 +15,16 @@ RSpec.describe AnalyticsDataLayer, type: :model do
 
   describe "#add_user_info" do
     let(:user) { create(:user) }
+    let(:course_year) { create(:course_year) }
 
     it "adds the user type to the analytics data" do
       data_layer.add_user_info(user)
       expect(data_layer.analytics_data[:userType]).to eq(user.user_description)
+    end
+
+    it "adds the correct year to the analytics data" do
+      data_layer.add_year_info(course_year)
+      expect(data_layer.analytics_data[:cipYear]).to eq("Year #{course_year.position}")
     end
 
     context "when the supplied user is nil" do


### PR DESCRIPTION
## Ticket and context

Ticket: [697](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?selectedIssue=CPDEL-697)

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Inspect a course year page. 
3. type dataLayer in to the console
4. You should see the course year 1 or 2 in the output for cipYear

![Screenshot 2021-07-16 at 10 46 57](https://user-images.githubusercontent.com/69353998/125928476-184bf895-108e-4a41-afd3-8293fdb37233.png)

