### PR TITLE
Update the users client path to point at new endpoint in R&P

### DIFF
--- a/app/models/register_and_partner_api/user.rb
+++ b/app/models/register_and_partner_api/user.rb
@@ -3,7 +3,7 @@
 module RegisterAndPartnerApi
   class User < RegisterAndPartnerApi::Resource
     def self.path(_params = nil)
-      "users"
+      "ecf-users"
     end
 
     def self.table_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |config|
 
   # Stub Register and Partner users api
   config.before(:each) do
-    stub_request(:get, /https:\/\/api\.example\.com\/api\/v1\/users\.json.*/)
+    stub_request(:get, /https:\/\/api\.example\.com\/api\/v1\/ecf-users\.json.*/)
         .with(
           headers: {
             "Accept" => "application/json,*/*",


### PR DESCRIPTION
We renamed an endpoint on R&P to better suit what it is doing - `users` is too generic for our case (we only get mentors and ects in it).

So we need to change the path we query.

The R&P change is nice - they added a copy of the endpoint, to give us time to switch. 

R&P PR: https://github.com/DFE-Digital/early-careers-framework/pull/744