### PR TITLE
Fix video bleeding in information blocks

### DIFF
--- a/app/webpacker/styles/govspeak.scss
+++ b/app/webpacker/styles/govspeak.scss
@@ -23,6 +23,7 @@
 
 @import "./govspeak/accordion";
 @import "./govspeak/call-to-action";
+@import "./govspeak/details";
 @import "./govspeak/section";
 @import "./govspeak/highlights";
 @import "./govspeak/quote";

--- a/app/webpacker/styles/govspeak/_details.scss
+++ b/app/webpacker/styles/govspeak/_details.scss
@@ -1,0 +1,5 @@
+.gem-c-govspeak {
+  .govuk-details {
+    padding-top: 5px;
+  }
+}

--- a/app/webpacker/styles/govspeak/_highlights.scss
+++ b/app/webpacker/styles/govspeak/_highlights.scss
@@ -4,5 +4,9 @@
     border-radius: 9px;
     padding: 40px;
     margin: 50px;
+    iframe {
+      width: 444px;
+      height: 269px;
+    }
   }
 }


### PR DESCRIPTION
## Ticket and context

Ticket: [755](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-755)

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Go to `/teach-first/year-1/autumn-1/topic-4/part-2` for videos in an information block that have been resized. 
3. Go to `/ambition/year-1/autumn-1/topic-2/part-1` or find a video not in an information block to check it's not had an effect on other videos. 

**Information block youtube video**
<img width="673" alt="Screenshot 2021-08-02 at 08 41 33" src="https://user-images.githubusercontent.com/69353998/127823456-4d94f3c7-ca42-41bb-8241-ae8e7d17eff6.png">

**Details spacing**
<img width="641" alt="Screenshot 2021-08-02 at 08 43 26" src="https://user-images.githubusercontent.com/69353998/127823061-249d7fca-60c4-478c-837b-5cab10fb934c.png">


