### PR TITLE
CPDEL-764 remove final unlinked breadcrumb

### DIFF
--- a/app/helpers/cip_breadcrumb_helper.rb
+++ b/app/helpers/cip_breadcrumb_helper.rb
@@ -6,19 +6,22 @@ module CipBreadcrumbHelper
   end
 
   def course_year_breadcrumbs(user, year)
-    [
-      home_crumb(user),
-      end_crumb(course_year_crumb(year, user)),
-    ]
+    array = []
+
+    array << home_crumb(user)
+    array << course_year_crumb(year, user) if editing_content?
+
+    array
   end
 
   def course_module_breadcrumbs(user, course_module)
-    module_crumb = course_module_crumb(course_module)
-    [
-      home_crumb(user),
-      course_year_crumb(course_module.course_year, user),
-      end_crumb(module_crumb),
-    ]
+    array = []
+
+    array << home_crumb(user)
+    array << course_year_crumb(course_module.course_year, user)
+    array << course_module_crumb(course_module) if editing_content?
+
+    array
   end
 
   def course_lesson_breadcrumbs(user, course_lesson)
@@ -27,7 +30,7 @@ module CipBreadcrumbHelper
     array << home_crumb(user)
     array << course_year_crumb(course_lesson.course_module.course_year, user) if course_lesson.course_module
     array << course_module_crumb(course_lesson.course_module) if course_lesson.course_module
-    array << end_crumb(course_lesson_crumb(course_lesson))
+    array << course_lesson_crumb(course_lesson) if editing_content?
 
     array
   end
@@ -40,7 +43,7 @@ module CipBreadcrumbHelper
     array << home_crumb(user)
     array << course_year_crumb(lesson.course_module.course_year, user) if lesson.course_module
     array << course_module_crumb(lesson.course_module) if lesson.course_module
-    array << end_crumb(mentor_material_crumb(mentor_material))
+    array << mentor_material_crumb(mentor_material) if editing_content?
 
     array
   end
@@ -75,7 +78,7 @@ private
     end
   end
 
-  def end_crumb(crumb)
-    action_name == "show" ? crumb[0] : crumb
+  def editing_content?
+    action_name == "edit"
   end
 end

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -26,12 +26,12 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:year_breadcrumbs) { helper.course_year_breadcrumbs(early_career_teacher, course_year) }
 
       it "returns an array for the course year breadcrumb" do
-        expect(year_breadcrumbs).to eq([["Home", "/dashboard"], expected_year_crumb])
+        expect(year_breadcrumbs).to eq([["Home", "/dashboard"]])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(year_breadcrumbs).to eql([["Home", "/dashboard"], expected_year_crumb[0]])
+        expect(year_breadcrumbs).to eql([["Home", "/dashboard"]])
       end
     end
 
@@ -39,12 +39,12 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:year_breadcrumbs) { helper.course_year_breadcrumbs(mentor, course_year) }
 
       it "returns an array for the course year breadcrumb" do
-        expect(year_breadcrumbs).to eq([["Home", "/dashboard"], expected_mentor_year_crumb])
+        expect(year_breadcrumbs).to eq([["Home", "/dashboard"]])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(year_breadcrumbs).to eql([["Home", "/dashboard"], expected_mentor_year_crumb[0]])
+        expect(year_breadcrumbs).to eql([["Home", "/dashboard"]])
       end
     end
 
@@ -52,7 +52,7 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:year_breadcrumbs) { helper.course_year_breadcrumbs(admin, course_year) }
 
       it "returns an array for the course year breadcrumb" do
-        expect(year_breadcrumbs).to eq([["Home", "/dashboard"], expected_year_crumb])
+        expect(year_breadcrumbs).to eq([["Home", "/dashboard"]])
       end
 
       it "returns a url for the end crumb when the action_name is edit" do
@@ -62,7 +62,7 @@ describe CipBreadcrumbHelper, type: :helper do
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(year_breadcrumbs).to eql([["Home", "/dashboard"], expected_year_crumb[0]])
+        expect(year_breadcrumbs).to eql([["Home", "/dashboard"]])
       end
     end
   end
@@ -72,17 +72,17 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_module_breadcrumb) { helper.course_module_breadcrumbs(early_career_teacher, course_module) }
 
       it "returns an array for the course module breadcrumb" do
-        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
+        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb])
       end
 
       it "returns a url for the end crumb when the action_name is edit" do
         allow(helper).to receive(:action_name) { "edit" }
-        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
+        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb,  expected_module_crumb])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_year_crumb, course_module.term_and_title])
+        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_year_crumb])
       end
     end
 
@@ -90,12 +90,12 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_module_breadcrumb) { helper.course_module_breadcrumbs(mentor, course_module) }
 
       it "returns an array for the course module breadcrumb" do
-        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_mentor_year_crumb, expected_module_crumb])
+        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_mentor_year_crumb])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_mentor_year_crumb, course_module.term_and_title])
+        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_mentor_year_crumb])
       end
     end
 
@@ -103,7 +103,7 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_module_breadcrumb) { helper.course_module_breadcrumbs(admin, course_module) }
 
       it "returns an array for the course module breadcrumb" do
-        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
+        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb])
       end
 
       it "returns a url for the end crumb when the action_name is edit" do
@@ -113,7 +113,7 @@ describe CipBreadcrumbHelper, type: :helper do
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_year_crumb, course_module.term_and_title])
+        expect(course_module_breadcrumb).to eql([["Home", "/dashboard"], expected_year_crumb])
       end
     end
   end
@@ -123,12 +123,12 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_lesson_breadcrumb) { helper.course_lesson_breadcrumbs(early_career_teacher, course_lesson) }
 
       it "returns an array for the course lesson breadcrumb" do
-        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb, expected_lesson_crumb])
+        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb, course_lesson.title])
+        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
       end
     end
 
@@ -136,12 +136,12 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_lesson_breadcrumb) { helper.course_lesson_breadcrumbs(mentor, course_lesson) }
 
       it "returns an array for the course lesson breadcrumb" do
-        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_mentor_year_crumb, expected_module_crumb, expected_lesson_crumb])
+        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_mentor_year_crumb, expected_module_crumb])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_lesson_breadcrumb).to eql([["Home", "/dashboard"], expected_mentor_year_crumb, expected_module_crumb, course_lesson.title])
+        expect(course_lesson_breadcrumb).to eql([["Home", "/dashboard"], expected_mentor_year_crumb, expected_module_crumb])
       end
     end
 
@@ -149,7 +149,7 @@ describe CipBreadcrumbHelper, type: :helper do
       let(:course_lesson_breadcrumb) { helper.course_lesson_breadcrumbs(admin, course_lesson) }
 
       it "returns an array for the course lesson breadcrumb" do
-        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb, expected_lesson_crumb])
+        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
       end
 
       it "returns the url for the end crumb when the action_name is edit" do
@@ -159,7 +159,7 @@ describe CipBreadcrumbHelper, type: :helper do
 
       it "returns just the title for the end crumb when the action_name is show" do
         allow(helper).to receive(:action_name) { "show" }
-        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb, course_lesson.title])
+        expect(course_lesson_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
       end
     end
   end

--- a/spec/helpers/cip_breadcrumb_helper_spec.rb
+++ b/spec/helpers/cip_breadcrumb_helper_spec.rb
@@ -77,7 +77,7 @@ describe CipBreadcrumbHelper, type: :helper do
 
       it "returns a url for the end crumb when the action_name is edit" do
         allow(helper).to receive(:action_name) { "edit" }
-        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb,  expected_module_crumb])
+        expect(course_module_breadcrumb).to eq([["Home", "/dashboard"], expected_year_crumb, expected_module_crumb])
       end
 
       it "returns just the title for the end crumb when the action_name is show" do


### PR DESCRIPTION
## Ticket and context

Ticket: [764](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?selectedIssue=CPDEL-764)

## Code review

### Is there anything weird that code reviewer should know?
There was a linked end crumbs so it needed a bit of tweaking to keep this. 

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Go to years, modules or lessons and there should be no end unlinked crumb
3. Login as an admin and go to edit content. 
4. The page you've just come from should be linked in the end crumb. 

**Page with no end unlinked crumb**

<img width="723" alt="Screenshot 2021-08-04 at 12 54 50" src="https://user-images.githubusercontent.com/69353998/128176620-51c9edfc-6efa-499b-a815-6b651b02d95c.png">

**Edit page with end linked crumb**

<img width="1016" alt="Screenshot 2021-08-04 at 12 57 13" src="https://user-images.githubusercontent.com/69353998/128176688-13006e0d-afbd-4c1d-99c4-3869c9c14a95.png">

