### PR TITLE
Add cohort to user sync

### DIFF
--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -32,6 +32,7 @@ class AnalyticsDataLayer
     @analytics_data[:userType] = user.user_description if user
     @analytics_data[:userRegisterAndPartnerId] = user.register_and_partner_id if user
     @analytics_data[:userCoreInductionProgramme] = user.core_induction_programme if user
+    @analytics_data[:cohort] = user.cohort if user
   end
 
   def add_cip_info(cip)

--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -31,8 +31,12 @@ class AnalyticsDataLayer
   def add_user_info(user)
     @analytics_data[:userType] = user.user_description if user
     @analytics_data[:userRegisterAndPartnerId] = user.register_and_partner_id if user
-    @analytics_data[:userCoreInductionProgramme] = user.core_induction_programme if user
-    @analytics_data[:cohort] = user.cohort if user
+    @analytics_data[:userCoreInductionProgramme] = add_cip_info(user.core_induction_programme) if user
+    @analytics_data[:cohortStartYear] = add_cohort_start_year(user) if user&.participant?
+  end
+
+  def add_cohort_start_year(user)
+    user.cohort&.start_year
   end
 
   def add_cip_info(cip)

--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -31,12 +31,8 @@ class AnalyticsDataLayer
   def add_user_info(user)
     @analytics_data[:userType] = user.user_description if user
     @analytics_data[:userRegisterAndPartnerId] = user.register_and_partner_id if user
-    @analytics_data[:userCoreInductionProgramme] = add_cip_info(user.core_induction_programme) if user
-    @analytics_data[:cohortStartYear] = add_cohort_start_year(user) if user&.participant?
-  end
-
-  def add_cohort_start_year(user)
-    user.cohort&.start_year
+    @analytics_data[:userCoreInductionProgramme] = user.core_induction_programme.name if user&.core_induction_programme
+    @analytics_data[:cohortStartYear] = user.cohort.start_year if user&.participant?
   end
 
   def add_cip_info(cip)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,11 @@ class User < ApplicationRecord
     participant_profile&.core_induction_programme
   end
 
+  def cohort
+    return early_career_teacher_profile.cohort if early_career_teacher?
+    return mentor_profile.cohort if mentor?
+  end
+
   def is_on_core_induction_programme?
     is_cip_participant? && core_induction_programme.present?
   end

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -76,6 +76,7 @@ module RegisterAndPartnerApi
         cip: user_from_api.attributes[:attributes][:core_induction_programme],
         induction_programme_choice: user_from_api.attributes[:attributes][:induction_programme_choice],
         registration_completed: user_from_api.attributes[:attributes][:registration_completed],
+        cohort: user_from_api.attributes[:attributes][:cohort],
       }
     end
 
@@ -97,6 +98,7 @@ module RegisterAndPartnerApi
       profile.core_induction_programme = get_core_induction_programme(attributes)
       profile.induction_programme_choice = attributes[:induction_programme_choice]
       profile.registration_completed = attributes[:registration_completed]
+      profile.cohort = get_cohort(attributes)
       profile.save!
     end
 
@@ -114,6 +116,10 @@ module RegisterAndPartnerApi
       CoreInductionProgramme.find_by(name: name)
     end
 
-    private_class_method :sync_users, :user_attributes_from, :find_or_create_user, :save_user, :get_core_induction_programme
+    def self.get_cohort(attributes)
+      Cohort.find_by(start_year: attributes[:cohort])
+    end
+
+    private_class_method :sync_users, :user_attributes_from, :find_or_create_user, :save_user, :get_core_induction_programme, :get_cohort
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,4 +4,6 @@
 
 load Rails.root.join("db/seeds/cip_seed.rb").to_s
 
+load Rails.root.join("db/seeds/cohort_seed.rb").to_s
+
 load Rails.root.join("db/seeds/dummy_structures.rb").to_s

--- a/db/seeds/cohort_seed.rb
+++ b/db/seeds/cohort_seed.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Cohort.find_or_create_by!(start_year: 2020)
+Cohort.find_or_create_by!(start_year: 2021)
+Cohort.find_or_create_by!(start_year: 2022)

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 unless Cohort.first
+  Cohort.create!(start_year: 2020)
   Cohort.create!(start_year: 2021)
   Cohort.create!(start_year: 2022)
 end
@@ -27,13 +28,13 @@ unless Rails.env.production?
     ect_user = User.find_or_create_by!(email: "#{cip_name_for_email}-early-career-teacher@example.com") do |u|
       u.full_name = "#{cip.name} ECT User"
     end
-    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: cip,
+    EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.find_by(start_year: 2021), core_induction_programme: cip,
                                                  induction_programme_choice: "core_induction_programme", registration_completed: true)
 
     mentor_user = User.find_or_create_by!(email: "#{cip_name_for_email}-mentor@example.com") do |u|
       u.full_name = "#{cip.name} Mentor User"
     end
-    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: cip,
+    MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.find_by(start_year: 2021), core_induction_programme: cip,
                                      induction_programme_choice: "core_induction_programme", registration_completed: true)
   end
 
@@ -41,10 +42,10 @@ unless Rails.env.production?
   ect_user = User.find_or_create_by!(email: "cip-less-ect@example.com") do |u|
     u.full_name = "CIP-less ECT User"
   end
-  EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.first, core_induction_programme: nil, induction_programme_choice: "core_induction_programme")
+  EarlyCareerTeacherProfile.find_or_create_by!(user: ect_user, cohort: Cohort.find_by(start_year: 2021), core_induction_programme: nil, induction_programme_choice: "core_induction_programme")
 
   mentor_user = User.find_or_create_by!(email: "cip-less-mentor@example.com") do |u|
     u.full_name = "CIP-less Mentor User"
   end
-  MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.first, core_induction_programme: nil, induction_programme_choice: "core_induction_programme")
+  MentorProfile.find_or_create_by!(user: mentor_user, cohort: Cohort.find_by(start_year: 2021), core_induction_programme: nil, induction_programme_choice: "core_induction_programme")
 end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-unless Cohort.first
-  Cohort.create!(start_year: 2020)
-  Cohort.create!(start_year: 2021)
-  Cohort.create!(start_year: 2022)
-end
-
 unless Rails.env.production?
   user = User.find_or_create_by!(email: "admin@example.com") do |u|
     u.full_name = "Admin User"

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     induction_programme_choice { "core_induction_programme" }
     registration_completed { true }
     guidance_seen { false }
+    cohort
   end
 end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     induction_programme_choice { "core_induction_programme" }
     registration_completed { true }
     guidance_seen { false }
+    cohort
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -9,7 +9,8 @@
         "user_type": "mentor",
         "core_induction_programme": "ucl",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": true
+        "registration_completed": true,
+        "cohort": 2021
       }
     },
     {
@@ -21,7 +22,8 @@
         "user_type": "mentor",
         "core_induction_programme": "none",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": true
+        "registration_completed": true,
+        "cohort": 2021
       }
     },
     {
@@ -33,7 +35,8 @@
         "user_type": "early_career_teacher",
         "core_induction_programme": "ucl",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": true
+        "registration_completed": true,
+        "cohort": 2021
       }
     },
     {
@@ -45,7 +48,8 @@
         "user_type": "other",
         "core_induction_programme": "ucl",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": false
+        "registration_completed": false,
+        "cohort": 2021
       }
     },
     {
@@ -57,7 +61,8 @@
         "user_type": "early_career_teacher",
         "core_induction_programme": "edt",
         "induction_programme_choice": "full_induction_programme",
-        "registration_completed": true
+        "registration_completed": true,
+        "cohort": 2021
       }
     },
       {
@@ -69,7 +74,21 @@
         "user_type": "early_career_teacher",
         "core_induction_programme": "teach_first",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": false
+        "registration_completed": false,
+        "cohort": 2021
+      }
+    },
+    {
+      "id": "d97erf90-845g43g32-q256-bde6763123g76",
+      "type": "user",
+      "attributes": {
+        "email": "nqt_plus_1_user@example.com",
+        "full_name": "Bob Belcher",
+        "user_type": "early_career_teacher",
+        "core_induction_programme": "ucl",
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": true,
+        "cohort": 2020
       }
     }
   ]

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AnalyticsDataLayer, type: :model do
     it "should add the correct cohort year to the analytics data" do
       user.early_career_teacher_profile.update!(cohort: create(:cohort, start_year: 2020))
       data_layer.add_user_info(user)
-      expect(data_layer.analytics_data[:cohort]).to eq(user.cohort)
+      expect(data_layer.analytics_data[:cohortStartYear]).to eq(user.cohort.start_year)
     end
 
     context "when the supplied user is nil" do

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AnalyticsDataLayer, type: :model do
   end
 
   describe "#add_user_info" do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :early_career_teacher) }
     let(:course_year) { create(:course_year) }
 
     it "adds the user type to the analytics data" do
@@ -25,6 +25,12 @@ RSpec.describe AnalyticsDataLayer, type: :model do
     it "adds the correct year to the analytics data" do
       data_layer.add_year_info(course_year)
       expect(data_layer.analytics_data[:cipYear]).to eq("Year #{course_year.position}")
+    end
+
+    it "should add the correct cohort year to the analytics data" do
+      user.early_career_teacher_profile.update!(cohort: create(:cohort, start_year: 2020))
+      data_layer.add_user_info(user)
+      expect(data_layer.analytics_data[:cohort]).to eq(user.cohort)
     end
 
     context "when the supplied user is nil" do

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe AnalyticsDataLayer, type: :model do
       expect(data_layer.analytics_data[:cipYear]).to eq("Year #{course_year.position}")
     end
 
+    it "adds the correct core induction programme name to the analytics data" do
+      data_layer.add_user_info(user)
+      expect(data_layer.analytics_data[:userCoreInductionProgramme]).to eq(user.core_induction_programme.name)
+    end
+
     it "should add the correct cohort year to the analytics data" do
       user.early_career_teacher_profile.update!(cohort: create(:cohort, start_year: 2020))
       data_layer.add_user_info(user)

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -5,20 +5,21 @@ require "rails_helper"
 RSpec.describe RegisterAndPartnerApi::SyncUsers do
   describe "::perform" do
     before do
+      create(:cohort, start_year: 2021)
       create(:core_induction_programme, name: "UCL")
     end
 
     it "imports all users returned" do
       expect {
         described_class.perform
-      }.to change(User, :count).by(5)
+      }.to change(User, :count).by(6)
     end
 
     it "does not create the users again" do
       expect {
         described_class.perform
         described_class.perform
-      }.to change(User, :count).by(5)
+      }.to change(User, :count).by(6)
     end
 
     it "does not create a user when given a user type of other" do
@@ -26,7 +27,7 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
 
       record = User.find_by(email: "user_type_other@example.com")
       expect(record.nil?).to be true
-      expect(User.count).to eql(5)
+      expect(User.count).to eql(6)
     end
 
     it "creates users with correct attributes" do
@@ -44,13 +45,22 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
       expect(record.core_induction_programme).not_to be_nil
     end
 
+    it "creates a user with a cohort year of 2020" do
+      create(:cohort, start_year: 2020)
+      described_class.perform
+
+      record = User.find_by(email: "nqt_plus_1_user@example.com")
+      expect(record.early_career_teacher?).to be true
+      expect(record.cohort.start_year).to eql(2020)
+    end
+
     it "updates an existing user that has changed their email address" do
       create(:user, register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934", email: "mentor-1@example.com")
 
       described_class.perform
 
       record = User.find_by(register_and_partner_id: "65abf54c-c7c2-490b-9bcd-bbb4e0aab934")
-      expect(User.count).to eql(5)
+      expect(User.count).to eql(6)
       expect(record.email).to eql("mentor@example.com")
     end
 


### PR DESCRIPTION
## Ticket and context

Ticket: [776](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89/backlog?selectedIssue=CPDEL-776)

We want to know whether a user is part of the 2020 cohort (NQT + 1) for our analytics data so we need to get this from R&P. We'll also want to distinguish between future cohorts and cut off access to the platform later down the line.

I'll open a separate PR on R&P to send that information. 

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

