### PR TITLE
Add docs and config for running jobs locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.active_job.queue_adapter = :delayed_job
   config.domain = ENV["DOMAIN"]
   config.gias_api_root = ENV["GIAS_API_ROOT"]
   # Don't care if the mailer can't send.

--- a/documentation/register_and_partner_api_setup.md
+++ b/documentation/register_and_partner_api_setup.md
@@ -19,4 +19,14 @@ We use an api on R&P that's hidden behind authentication. If you need to work on
 ### Generating new R&P token
 
 Follow the steps in R&P repo - most likely it will involve using a rails console. Tokens in there are called `EngageAndLearnApiToken`.
-Make sure you note the unhashed token - it won't be available after you generate it. 
+Make sure you note the unhashed token - it won't be available after you generate it.
+
+### Setting up background jobs
+
+There are background jobs that sync users from R&P on a cron schedule.
+To get this running you will need to start the jobs worker and run an
+initial rake task to schedule the first jobs (subsequent job runs
+schedule the next one to run based on the cron schedule)
+
+1. run `bundle exec rake jobs:work`
+2. run `bundle exec rake cron:schedule`


### PR DESCRIPTION
Previously there was no active job queue adapter specified so it would use the async adapter:
https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html

This meant that the `rake cron:schedule` task would just run the tasks once and not reschedule them
as the async adapter is in-memory.

Set the queue adapter to be delayed_job as it is in other environments and add documentation on
how to run it locally.

## Ticket and context

Ticket:

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

n/a

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
