### PR TITLE
[CPDEL-649] Hide "Create year" button when there are already 2

### DIFF
--- a/app/helpers/year_helper.rb
+++ b/app/helpers/year_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module YearHelper
+  def show_create_year?(cip)
+    cip.course_years.count < 2
+  end
+end

--- a/app/views/core_induction_programmes/years/show.html.erb
+++ b/app/views/core_induction_programmes/years/show.html.erb
@@ -16,7 +16,9 @@
 
     <% if current_user&.admin? %>
       <div class="govuk-button-group">
-        <%= govuk_link_to "Create CIP Year", cip_create_year_path(@cip), button: true %>
+        <% if show_create_year?(@cip) %>
+          <%= govuk_link_to "Create CIP Year", cip_create_year_path(@cip), button: true %>
+        <% end %>
         <%= govuk_link_to "Create CIP Module", cip_create_module_path(@cip), button: true %>
         <%= govuk_link_to "Create CIP Lesson", cip_create_lesson_path(@cip), button: true %>
         <%= govuk_link_to "Edit year content", edit_year_path(@course_year), button: true %>

--- a/spec/cypress/integration/CipYears.feature
+++ b/spec/cypress/integration/CipYears.feature
@@ -24,6 +24,20 @@ Feature: Core Induction Programme years
     Then "page body" should contain "New test title"
     And the page should be accessible
 
+  Scenario: Admins can create years, but not more than two
+    Given course_year was created
+    And I am logged in as "admin"
+    And I am on "core induction programme show" page
+
+    When I click on "link" containing "Create CIP Year"
+    And I type "Year 2" into "year title input"
+    And I type "Learn better stuff than year 1" into "content input"
+    And I click on "button" containing "Create"
+
+    Then I should be on "core induction programme year" page
+    And "page body" should contain "Year 2"
+    And "page body" should not contain "Create CIP Year"
+
   Scenario: ECTs can view but not edit years
     Given I am logged in as "early_career_teacher" with id "53960d7f-1308-4de1-a56d-de03ea8e1d9c"
     And scenario "ect_cip" has been ran


### PR DESCRIPTION
There can be a maximum of 2 CIP years. There will be an error trying to load any CIP year if
there are 3 in total, because a route can't be generated for the third year.

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-649

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
