### PR TITLE
Set default docker vars to null

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -14,9 +14,11 @@ variable paas_app_docker_image {
 }
 
 variable docker_username {
+  default = null
 }
 
 variable docker_password {
+  default = null
 }
 
 variable paas_app_start_timeout {


### PR DESCRIPTION
There were some fixes to dockerhub/terraform made a couple days ago on R&P and [E&L](https://github.com/DFE-Digital/ecf-engage-and-learn/pull/235), although R&Ps destroy workflow didn't work correctly. This is just a [copy of their change](https://github.com/DFE-Digital/early-careers-framework/pull/884) to prevent this happening to us as well. 

### Changes proposed in this pull request
Set default values to the docker variables in terraform.