### PR TITLE
Singularize self-study sessions when there is only 1

### DIFF
--- a/app/views/core_induction_programmes/years/_module_list.html.erb
+++ b/app/views/core_induction_programmes/years/_module_list.html.erb
@@ -31,7 +31,7 @@
           <hr class="govuk-section-break govuk-section-break--visible" />
           <div class="app-task-list__section">
             <div class="app-task-list__flex">
-              <span><%= course_module.self_study_lessons.count %> self-study <%= "session".pluralize(course_module.course_lessons.count) %></span>
+              <span><%= pluralize(course_module.self_study_lessons.count, "self-study session") %></span>
 
               <%= render ProgressLabelComponent.new progress: course_module.progress %>
             </div>


### PR DESCRIPTION
## Ticket and context

Ticket: [796](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?selectedIssue=CPDEL-796)

It was using the wrong number to pluralize, i.e `course_lessons` instead of `self_study_lessons`

## Code review

### Is there anything weird that code reviewer should know?

Nope, everything is straightforward.

**from**
<img width="707" alt="Screenshot 2021-08-26 at 17 06 35" src="https://user-images.githubusercontent.com/69353998/130997300-376ec624-4b7d-4033-98ac-7a258f1a4c4a.png">

**to**
<img width="711" alt="Screenshot 2021-08-26 at 17 06 20" src="https://user-images.githubusercontent.com/69353998/130997330-e90d0a2a-9813-4391-9ecf-15e6892bdf02.png">
