### PR TITLE
Use iso8601 format when calling ecf-users api

### DIFF
--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -18,7 +18,7 @@ module RegisterAndPartnerApi
     def self.perform(all: false)
       new_sync_time = Time.zone.now - 1.minute
       last_sync = SyncUsersTimer.last_sync
-      base_query = all ? {} : { filter: { updated_since: last_sync } }
+      base_query = all ? {} : { filter: { updated_since: last_sync&.iso8601 } }
 
       perform_pagination(base_query)
 


### PR DESCRIPTION
This api has recently changed to have a stricter parsing of the updated_since parameter and is now failing with bad
request because the timestamp we were sending was not in iso8601 format

## Ticket and context

Ticket:

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
- [x] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
