### PR TITLE
CPDEL-835 Fix nqt+1 invites

### DIFF
--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -86,7 +86,9 @@ module RegisterAndPartnerApi
 
       assign_user_attributes(attributes, user, profile)
 
-      needs_inviting = profile.registration_completed_changed? && profile.registration_completed?
+      registration_changed_to_completed = profile.registration_completed_changed? && profile.registration_completed? && !user.is_an_nqt_plus_one_ect?
+      newly_created_nqt_plus_one_ect = !user.persisted? && user.is_an_nqt_plus_one_ect?
+      needs_inviting = registration_changed_to_completed || newly_created_nqt_plus_one_ect
 
       user.save!
       profile.save!

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -103,6 +103,19 @@
         "registration_completed": false,
         "cohort": 2021
       }
+    },
+    {
+      "id": "4d4e272a-4ff9-459a-9175-2135c744846e",
+      "type": "user",
+      "attributes": {
+        "email": "nqtplusonenotregistered@example.com",
+        "full_name": "John Doe",
+        "user_type": "early_career_teacher",
+        "core_induction_programme": "ucl",
+        "induction_programme_choice": "core_induction_programme",
+        "registration_completed": false,
+        "cohort": 2020
+      }
     }
   ]
 }


### PR DESCRIPTION
## Ticket and context

Bug from original ticket: https://dfedigital.atlassian.net/browse/CPDEL-835

Found during end to end testing, we don't add nqt+1 participants in the typical way, so they won't be validated. So relax this check if the user is an nqt+1 ect.

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
