### PR TITLE
Fix nqt+1 invites again

### DIFF
--- a/app/models/invite_email_ect.rb
+++ b/app/models/invite_email_ect.rb
@@ -12,7 +12,7 @@ class InviteEmailEct < TrackedEmail
   def send!(force_send: false)
     return unless user.is_on_core_induction_programme?
 
-    can_send_automatically = email_sending_enabled? && user.registered_participant?
+    can_send_automatically = email_sending_enabled? && (user.registered_participant? || user.is_an_nqt_plus_one_ect?)
     if can_send_automatically || force_send
       super
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,9 +14,11 @@ FactoryBot.define do
 
     transient do
       cohort_year { nil }
+      registration_completed { nil }
       profile_attributes do
         {}.tap do |attrs|
           attrs.merge!(cohort_year: cohort_year) if cohort_year
+          attrs.merge!(registration_completed: registration_completed) unless registration_completed.nil?
         end
       end
     end

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -110,11 +110,14 @@ RSpec.describe TrackedEmail, type: :model do
       end
 
       context "the user is nqt+1" do
-        let(:ect) { create(:user, :early_career_teacher, cohort_year: 2020) }
+        let(:ect) { create(:user, :early_career_teacher, cohort_year: 2020, registration_completed: false) }
 
         it "sends the ect welcome email" do
           expect(UserMailer).to receive(:nqt_plus_one_welcome_email).with(ect).and_call_original
           invite_email_ect.send!
+          expect(invite_email_ect.reload.sent?).to be_truthy
+          expect(invite_email_ect.notify_id).to eq("test_id")
+          expect(invite_email_ect.sent_to).to eq(ect.email)
         end
       end
     end


### PR DESCRIPTION
We recently relaxed the constraint for registration to be completed for nqt+1 participants in the user sync, though there is an extra check in the  email itself that also needs to be relaxed

## Ticket and context

Ticket:

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
