### PR TITLE
Adds reminder email for mentors to sign in

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,6 +5,7 @@ class UserMailer < ApplicationMailer
   ECT_WELCOME_TEMPLATE = "652fea63-1344-4608-a957-6046dc27120b"
   SIGN_IN_EMAIL_TEMPLATE = "a3219fe5-e320-48ee-a386-7a244785785c"
   NQT_PLUS_ONE_WELCOME_TEMPLATE = "338059be-18d5-4ca6-9351-bb6d45bad2ae"
+  MENTOR_SIGN_IN_REMINDER_EMAIL = "7dce3037-50fc-46ed-b070-a7e10e2f4379"
 
   def mentor_welcome_email(user)
     sign_in_url = Rails.application.routes.url_helpers.new_user_session_url(host: Rails.application.config.domain,
@@ -61,6 +62,21 @@ class UserMailer < ApplicationMailer
         full_name: user.full_name,
         sign_in_url: url,
         token_expiry: token_expiry,
+      },
+    )
+  end
+
+  def mentor_sign_in_reminder_email(user)
+    sign_in_url = Rails.application.routes.url_helpers.new_user_session_url(host: Rails.application.config.domain,
+                                                                            **UtmService.email(:new_mentor))
+    template_mail(
+      MENTOR_SIGN_IN_REMINDER_EMAIL,
+      to: user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        full_name: user.full_name,
+        sign_in_url: sign_in_url,
       },
     )
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -68,7 +68,7 @@ class UserMailer < ApplicationMailer
 
   def mentor_sign_in_reminder_email(user)
     sign_in_url = Rails.application.routes.url_helpers.new_user_session_url(host: Rails.application.config.domain,
-                                                                            **UtmService.email(:new_mentor))
+                                                                            **UtmService.email(:mentor_sign_in_reminder))
     template_mail(
       MENTOR_SIGN_IN_REMINDER_EMAIL,
       to: user.email,

--- a/app/models/reminder_email_mentor.rb
+++ b/app/models/reminder_email_mentor.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ReminderEmailMentor < TrackedEmail
+  def mail_to_send
+    UserMailer.mentor_sign_in_reminder_email(user)
+  end
+
+  def send!(force_send: false)
+    return unless user.is_on_core_induction_programme?
+
+    can_send_automatically = email_sending_enabled? && user.registered_participant?
+    if can_send_automatically || force_send
+      super
+    end
+  end
+end

--- a/app/services/remind_participants.rb
+++ b/app/services/remind_participants.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class RemindParticipants
+  def self.run(emails, force_send: false)
+    logger.info "Emailing Participants"
+
+    user = nil
+    emails.each do |email|
+      user = User.find_by(email: email)
+      email = create_reminder_email_for_user(user)
+      email.send!(force_send: force_send)
+    rescue StandardError
+      logger.info "Error emailing user, id: #{user&.id} ... skipping"
+    end
+  end
+
+  def self.create_reminder_email_for_user(user)
+    return unless user.is_on_core_induction_programme?
+
+    if user.mentor?
+      ReminderEmailMentor.create!(user: user)
+    end
+  end
+
+  def self.logger
+    @logger ||= Rails.logger
+  end
+
+  private_class_method :create_reminder_email_for_user, :logger
+end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -6,6 +6,7 @@ class UtmService
     new_early_career_teacher: "new-early-career-teacher",
     new_nqt_plus_one: "new-nqt-plus-one",
     sign_in: "sign-in",
+    mentor_sign_in_reminder: "mentor-sign-in-reminder",
   }.freeze
 
   def self.email(campaign)

--- a/spec/models/tracked_email_spec.rb
+++ b/spec/models/tracked_email_spec.rb
@@ -210,4 +210,35 @@ RSpec.describe TrackedEmail, type: :model do
       end
     end
   end
+
+  describe "sending mentor reminder" do
+    let(:mentor) { create(:user, :mentor) }
+    let(:reminder_email_mentor) { ReminderEmailMentor.create!(user: mentor) }
+
+    context "email sending is disabled" do
+      before do
+        allow(ENV).to receive(:[]).with("EMAIL_SENDING_ENABLED").and_return("false")
+      end
+
+      it "does not send the email" do
+        reminder_email_mentor.send!
+        expect(reminder_email_mentor.reload.sent?).to be_falsey
+        expect(reminder_email_mentor.notify_id).to be_nil
+        expect(reminder_email_mentor.sent_to).to be_nil
+      end
+    end
+
+    context "email sending is enabled" do
+      before do
+        allow(ENV).to receive(:[]).with("EMAIL_SENDING_ENABLED").and_return("true")
+      end
+
+      it "sends the mentor a reminder to sign in" do
+        reminder_email_mentor.send!
+        expect(reminder_email_mentor.reload.sent?).to be_truthy
+        expect(reminder_email_mentor.notify_id).to eq("test_id")
+        expect(reminder_email_mentor.sent_to).to eq(mentor.email)
+      end
+    end
+  end
 end

--- a/spec/services/remind_participants_spec.rb
+++ b/spec/services/remind_participants_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemindParticipants do
+  let(:mentor) { create(:user, :mentor) }
+  let(:ect) { create(:user, :early_career_teacher) }
+
+  describe "#run" do
+    it "creates a mentor email when given mentor user" do
+      expect { RemindParticipants.run([mentor.email]) }.to change { ReminderEmailMentor.count }.by(1)
+    end
+
+    it "does not create an email when given another user type" do
+      expect { RemindParticipants.run([ect.email]) }.not_to(change { ReminderEmailMentor.count })
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [801](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?selectedIssue=CPDEL-801)

We want to send a reminder email to all private beta mentors. It's going to be ran manually in the terminal with a list of emails we have already. 

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Run it manually in the console. 

<img width="750" alt="Screenshot 2021-09-24 at 14 19 00" src="https://user-images.githubusercontent.com/69353998/134681168-d48916f9-8c68-4c21-b169-163bd29afc82.png">


