### PR TITLE
Add i.ytimg.com to img_src

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,7 +10,7 @@ SecureHeaders::Configuration.default do |config|
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
 
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
-  youtube = %w[youtube.com www.youtube.com]
+  youtube = %w[youtube.com www.youtube.com i.ytimg.com]
   amazon = %w[paas-s3-broker-prod-lon-ac28a7a5-2bc2-4d3b-8d16-a88eaef65526.s3.amazonaws.com]
 
   config.csp = SecureHeaders::OPT_OUT


### PR DESCRIPTION
This is the youtube thumbnail domain

```ruby
{"csp-report"=>{"blocked-uri"=>"https://i.ytimg.com/vi_webp/5Go9F0pYbaA/mqdefault.webp", "disposition"=>"report", "document-uri"=>"https://support-for-early-career-teachers.education.gov.uk/teach-first/year-1/autumn-1/topic-4/part-2", "effective-directive"=>"img-src", "original-policy"=>"default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src 'self'; connect-src 'self' *.ingest.sentry.io www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com youtube.com www.youtube.com; font-src 'self' *.gov.uk fonts.gstatic.com; form-action 'self'; frame-ancestors 'self'; frame-src 'self' www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com youtube.com www.youtube.com; img-src 'self' data: *.gov.uk www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com youtube.com www.youtube.com paas-s3-broker-prod-lon-ac28a7a5-2bc2-4d3b-8d16-a88eaef65526.s3.amazonaws.com; manifest-src 'self'; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.uk www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com youtube.com www.youtube.com; style-src 'self' 'unsafe-inline' *.gov.uk fonts.googleapis.com www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com youtube.com www.youtube.com; worker-src 'self'; report-uri /csp_reports", "referrer"=>"https://support-for-early-career-teachers.education.gov.uk/teach-first/year-1/autumn-1/topic-4/part-1", "script-sample"=>"", "status-code"=>0, "violated-directive"=>"img-src"}}
```
