### PR TITLE
Replace PERSONAL_TOKEN in deploy to prod workflow

### DIFF
--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -62,7 +62,7 @@ jobs:
           restrictions: |
             null
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update master
         run: |
@@ -102,4 +102,4 @@ jobs:
           restrictions: |
             null
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
These steps are failing with 404 errors. Best guess is that this personal token belonged to @kicferk1 who has now been removed from the github org.
We should be able to use GITHUB_TOKEN instead https://docs.github.com/en/actions/security-guides/automatic-token-authentication, and this is
already used in an earlier step in the workflow.

## Ticket and context

Ticket:

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
