### PR TITLE
Allow unregistered nqt_plus_one_ects to sign in

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -126,7 +126,7 @@ private
 
     return user if user_already_accessed_the_service?(user)
 
-    unless user.registered_participant?
+    unless user.registered_participant? || user.is_an_nqt_plus_one_ect?
       user.errors.add :email, "Please complete your registration"
     end
 

--- a/spec/cypress/integration/Login.feature
+++ b/spec/cypress/integration/Login.feature
@@ -31,6 +31,13 @@ Feature: Login
     And I click the submit button
     Then "page body" should contain "Welcome Demo User"
 
+  Scenario: NQT plus one login
+    Given user was created as "early_career_teacher" with email "nqt_plus_one@example.com" and full_name "Demo User" and account_created "false" and registration_completed "false" and cohort_year "2020"
+    And I am on "sign in" page
+    When I type "nqt_plus_one@example.com" into "email input"
+    And I click the submit button
+    Then "page body" should contain "Welcome Demo User"
+
   Scenario: Mentor login
     Given user was created as "mentor" with email "mentor@example.com" and full_name "Demo Mentor User" and account_created "false"
     And I am on "sign in" page

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe "Users::Sessions", type: :request do
         end
       end
 
+      context "when a nqt plus one user isn't registered and has not accessed the service prior to public beta" do
+        it "redirects to dashboard" do
+          ect.early_career_teacher_profile.cohort.update!(start_year: 2020)
+          ect.early_career_teacher_profile.update!(registration_completed: false)
+          post "/users/sign_in", params: { user: { email: ect.email } }
+          expect(response).to redirect_to(dashboard_path)
+          expect(ect.reload.last_sign_in_at).not_to be_nil
+        end
+      end
+
       context "when a user's induction programme choice is a full induction programme" do
         it "renders sign_in page" do
           ect.early_career_teacher_profile.full_induction_programme!


### PR DESCRIPTION
## Ticket and context 

We've been contacted via [support](https://teachercpdhelp.zendesk.com/agent/tickets/10830) about nqt plus one users not being able to log in. The user is given the error to register. 

We had a change to send an invite to nqt plus one users that hadn't completed validation on ECF so that they can access the service. However the user session controller still checks that the user has completed registration. 

This change should allow nqt plus one users that haven't completed validation to login. 

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
