### PR TITLE
Fix check nqt plus one cohort year on user sync

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
     - 'vendor/**/*'
     - 'db/seeds/cip_*.rb'
 
+Naming/VariableNumber:
+  Exclude:
+    - 'app/services/register_and_partner_api/sync_users.rb'
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/app/services/register_and_partner_api/sync_users.rb
+++ b/app/services/register_and_partner_api/sync_users.rb
@@ -83,12 +83,11 @@ module RegisterAndPartnerApi
     def self.create_or_update_user(attributes, profile_class)
       user = ::User.find_or_initialize_by(register_and_partner_id: attributes[:register_and_partner_id])
       profile = profile_class.find_or_initialize_by(user: user)
-
       assign_user_attributes(attributes, user, profile)
 
       registration_changed_to_completed = profile.registration_completed_changed? && profile.registration_completed? && !user.is_an_nqt_plus_one_ect?
-      newly_created_nqt_plus_one_ect = !user.persisted? && user.is_an_nqt_plus_one_ect?
-      needs_inviting = registration_changed_to_completed || newly_created_nqt_plus_one_ect
+      cohort_changed_to_2020 = profile.cohort_id_changed? && profile.cohort.start_year == 2020
+      needs_inviting = registration_changed_to_completed || cohort_changed_to_2020
 
       create_or_destroy_cip_change_message(user, attributes)
 

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :cohort do
+    initialize_with { Cohort.find_or_create_by(start_year: start_year) }
     start_year { Faker::Date.between(from: "2020-01-01", to: "2099-12-31").year }
   end
 end

--- a/spec/fixtures/files/api/users.json
+++ b/spec/fixtures/files/api/users.json
@@ -111,7 +111,8 @@
         "user_type": "early_career_teacher",
         "core_induction_programme": "teach_first",
         "induction_programme_choice": "core_induction_programme",
-        "registration_completed": true
+        "registration_completed": true,
+        "cohort": 2021
       }
     },
     {

--- a/spec/services/register_and_partner_api/sync_users_spec.rb
+++ b/spec/services/register_and_partner_api/sync_users_spec.rb
@@ -131,13 +131,22 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
           end
         end
 
-        context "user is an nqt-plus one ect" do
-          it "should not create an invite" do
-            create(:user, :early_career_teacher, email: "nqtplusonenotregistered@example.com", register_and_partner_id: "4d4e272a-4ff9-459a-9175-2135c744846e")
+        context "user changes cohort from 2021 to 2020" do
+          it "should create an invite" do
+            create(:user, :early_career_teacher, email: "nqtplusonenotregistered@example.com", register_and_partner_id: "4d4e272a-4ff9-459a-9175-2135c744846e", cohort_year: 2021)
 
             allow(InviteParticipants).to receive(:run)
             described_class.perform
+            expect(InviteParticipants).to have_received(:run).with(["nqtplusonenotregistered@example.com"])
+          end
+        end
 
+        context "user cohort stays as 2020" do
+          it "should not create an invite" do
+            create(:user, :early_career_teacher, email: "nqtplusonenotregistered@example.com", register_and_partner_id: "4d4e272a-4ff9-459a-9175-2135c744846e", cohort_year: 2020)
+
+            allow(InviteParticipants).to receive(:run)
+            described_class.perform
             expect(InviteParticipants).not_to have_received(:run).with(["nqtplusonenotregistered@example.com"])
           end
         end
@@ -197,7 +206,6 @@ RSpec.describe RegisterAndPartnerApi::SyncUsers do
               core_induction_programme: CoreInductionProgramme.find_by_name("UCL"),
             )
             user.participant_profile.update!(guidance_seen: true)
-
             expect { described_class.perform }.to change { CipChangeMessage.count }.by(1)
           end
         end


### PR DESCRIPTION
## Context

We had an issue where a user was created on ECF side with a cohort of 2021. This was incorrect, so they were changed to 2020. Currently we don't do a check to see if an ECT has changed cohort year from 2021 -> 2020. The ECT would then not receive and invite email, which is needed to sign in (see user controller). This PR changes so we check whether the cohort id has changed and if the cohort start year is 2020. 

Any ECTs that switch to cohort start year 2020 should now receive the invite email. 
