### PR TITLE
Fix not null constraint for users/full name

### DIFF
--- a/db/migrate/20220228110243_fix_null_constraint_users_full_name.rb
+++ b/db/migrate/20220228110243_fix_null_constraint_users_full_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FixNullConstraintUsersFullName < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :users, :full_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_18_105019) do
+ActiveRecord::Schema.define(version: 2022_02_28_110243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
The previous migration to set this actually set null to false (it was run once correctly and then changed to be incorrect after rubocop complained about something)

## Ticket and context

Ticket:

## Code review

### Is there anything weird that code reviewer should know?
Nope, everything is straightforward.

### Review Checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests
- [ ] All forms have an `id` attribute on them

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
